### PR TITLE
Automatic scheduling

### DIFF
--- a/ongabot/handler/__init__.py
+++ b/ongabot/handler/__init__.py
@@ -7,6 +7,7 @@ from .neweventcommandhandler import NewEventCommandHandler
 from .canceleventcommandhandler import CancelEventCommandHandler
 from .ongacommandhandler import OngaCommandHandler
 from .startcommandhandler import StartCommandHandler
+from .schedulecommandhandler import ScheduleCommandHandler
 
 __all__ = (
     "EventPollAnswerHandler",
@@ -16,4 +17,5 @@ __all__ = (
     "CancelEventCommandHandler",
     "OngaCommandHandler",
     "StartCommandHandler",
+    "ScheduleCommandHandler"
 )

--- a/ongabot/handler/__init__.py
+++ b/ongabot/handler/__init__.py
@@ -8,6 +8,7 @@ from .canceleventcommandhandler import CancelEventCommandHandler
 from .ongacommandhandler import OngaCommandHandler
 from .startcommandhandler import StartCommandHandler
 from .schedulecommandhandler import ScheduleCommandHandler
+from .deschedulecommandhandler import DeScheduleCommandHandler
 
 __all__ = (
     "EventPollAnswerHandler",
@@ -17,5 +18,6 @@ __all__ = (
     "CancelEventCommandHandler",
     "OngaCommandHandler",
     "StartCommandHandler",
-    "ScheduleCommandHandler"
+    "ScheduleCommandHandler",
+    "DeScheduleCommandHandler"
 )

--- a/ongabot/handler/__init__.py
+++ b/ongabot/handler/__init__.py
@@ -19,5 +19,5 @@ __all__ = (
     "OngaCommandHandler",
     "StartCommandHandler",
     "ScheduleCommandHandler",
-    "DeScheduleCommandHandler"
+    "DeScheduleCommandHandler",
 )

--- a/ongabot/handler/deschedulecommand.py
+++ b/ongabot/handler/deschedulecommand.py
@@ -11,12 +11,12 @@ _logger = logging.getLogger(__name__)
 class DeScheduleCommandHandler(CommandHandler):
     """ Handler for /schedule command """
 
-    def __init__(self):
+    def __init__(self) -> None:
         CommandHandler.__init__(self, "deschedule", callback=callback)
 
 
 @log
-def callback(update: Update, context: CallbackContext):
+def callback(update: Update, context: CallbackContext) -> None:
     """ Cancels existing jobs """
     _logger.debug("update:\n%s", update)
 

--- a/ongabot/handler/deschedulecommand.py
+++ b/ongabot/handler/deschedulecommand.py
@@ -1,0 +1,31 @@
+"""This module contains the DeScheduleCommandHandler class."""
+import logging
+from telegram import Update
+from telegram.ext import CommandHandler, CallbackContext
+
+from utils.log import log
+
+_logger = logging.getLogger(__name__)
+
+
+class DeScheduleCommandHandler(CommandHandler):
+    """ Handler for /schedule command """
+    def __init__(self):
+        CommandHandler.__init__(self, "deschedule", callback=callback)
+
+
+@log
+def callback(update: Update, context: CallbackContext):
+    """ Cancels existing jobs """
+    _logger.debug("update:\n%s", update)
+
+    current_jobs = context.job_queue.get_jobs_by_name("Weekly scheduled poll creation job")
+
+    if not current_jobs:
+        update.message.reply_text('No jobs to cancel')
+        return
+
+    for job in current_jobs:
+        job.schedule_removal()
+
+    update.message.reply_text('Job cancelled successfully. Polls will no longer be automatically created')

--- a/ongabot/handler/deschedulecommand.py
+++ b/ongabot/handler/deschedulecommand.py
@@ -10,6 +10,7 @@ _logger = logging.getLogger(__name__)
 
 class DeScheduleCommandHandler(CommandHandler):
     """ Handler for /schedule command """
+
     def __init__(self):
         CommandHandler.__init__(self, "deschedule", callback=callback)
 
@@ -22,10 +23,12 @@ def callback(update: Update, context: CallbackContext):
     current_jobs = context.job_queue.get_jobs_by_name("Weekly scheduled poll creation job")
 
     if not current_jobs:
-        update.message.reply_text('No jobs to cancel')
+        update.message.reply_text("No jobs to cancel")
         return
 
     for job in current_jobs:
         job.schedule_removal()
 
-    update.message.reply_text('Job cancelled successfully. Polls will no longer be automatically created')
+    update.message.reply_text(
+        "Job cancelled successfully. Polls will no longer be automatically created"
+    )

--- a/ongabot/handler/deschedulecommandhandler.py
+++ b/ongabot/handler/deschedulecommandhandler.py
@@ -9,7 +9,7 @@ _logger = logging.getLogger(__name__)
 
 
 class DeScheduleCommandHandler(CommandHandler):
-    """ Handler for /schedule command """
+    """Handler for /schedule command"""
 
     def __init__(self) -> None:
         CommandHandler.__init__(self, "deschedule", callback=callback)
@@ -17,7 +17,7 @@ class DeScheduleCommandHandler(CommandHandler):
 
 @log
 def callback(update: Update, context: CallbackContext) -> None:
-    """ Cancels existing jobs """
+    """Cancels existing jobs"""
     _logger.debug("update:\n%s", update)
 
     current_jobs = context.job_queue.get_jobs_by_name("Weekly scheduled poll creation job")

--- a/ongabot/handler/neweventcommandhandler.py
+++ b/ongabot/handler/neweventcommandhandler.py
@@ -31,7 +31,7 @@ def callback(update: Update, context: CallbackContext) -> None:
     pinned_poll = context.chat_data.get("pinned_poll_msg")
 
     if pinned_poll is not None:
-        next_wed = helper.get_upcoming_wednesday_date(date.today()).strftime("%Y-%m-%d")
+        next_wed = helper.get_upcoming_date(date.today(), 'wednesday').strftime("%Y-%m-%d")
         if next_wed in pinned_poll.poll.question:
             context.bot.send_message(
                 update.effective_chat.id,
@@ -73,7 +73,7 @@ def callback(update: Update, context: CallbackContext) -> None:
 def create_poll_text() -> str:
     """Create text field for poll"""
     title = "Event: ONGA"
-    when = f"When: {helper.get_upcoming_wednesday_date(date.today())}"
+    when = f"When: {helper.get_upcoming_date(date.today(), 'wednesday')}"
     text = f"{title}\n{when}"
     return text
 

--- a/ongabot/handler/neweventcommandhandler.py
+++ b/ongabot/handler/neweventcommandhandler.py
@@ -31,7 +31,7 @@ def callback(update: Update, context: CallbackContext) -> None:
     pinned_poll = context.chat_data.get("pinned_poll_msg")
 
     if pinned_poll is not None:
-        next_wed = helper.get_upcoming_date(date.today(), 'wednesday').strftime("%Y-%m-%d")
+        next_wed = helper.get_upcoming_date(date.today(), "wednesday").strftime("%Y-%m-%d")
         if next_wed in pinned_poll.poll.question:
             context.bot.send_message(
                 update.effective_chat.id,

--- a/ongabot/handler/schedulecommand.py
+++ b/ongabot/handler/schedulecommand.py
@@ -1,6 +1,9 @@
 """This module contains the ScheduleCommandHandler class."""
 import logging
+import typing
 from datetime import date, datetime, timedelta
+from typing import Any
+
 from telegram import Update
 from telegram.ext import CommandHandler, CallbackContext
 from utils.log import log
@@ -97,4 +100,7 @@ def is_args_valid(day: str) -> bool:
 def create_poll(context: CallbackContext) -> None:
     """ Creates a new poll by calling /neweventcommand """
     _logger.debug("Poll creation is triggered by timer on %s", datetime.now())
-    create_new_poll(context.job.context["update"], context.job.context["context"])
+    create_new_poll(
+        typing.cast(typing.Dict[str, Any], context.job.context)["update"],
+        typing.cast(typing.Dict[str, Any], context.job.context)["context"],
+    )

--- a/ongabot/handler/schedulecommand.py
+++ b/ongabot/handler/schedulecommand.py
@@ -1,6 +1,6 @@
 """This module contains the ScheduleCommandHandler class."""
 import logging
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from telegram import Update
 from telegram.ext import CommandHandler, CallbackContext
 from utils.log import log
@@ -14,12 +14,12 @@ _logger = logging.getLogger(__name__)
 class ScheduleCommandHandler(CommandHandler):
     """ Handler for /schedule command """
 
-    def __init__(self):
+    def __init__(self) -> None:
         CommandHandler.__init__(self, "schedule", callback=callback)
 
 
 @log
-def callback(update: Update, context: CallbackContext):
+def callback(update: Update, context: CallbackContext) -> None:
     """ Schedule a poll creation job to run every week """
     job_name = "Weekly scheduled poll creation job"
     day_to_schedule = "sunday"
@@ -49,11 +49,19 @@ def callback(update: Update, context: CallbackContext):
 
     poll_creation_dto = {"context": context, "update": update}
 
-    upcoming_scheduled_date = helper.get_upcoming_date(datetime.now(), day_to_schedule)
+    upcoming_scheduled_date = helper.get_upcoming_date(date.today(), day_to_schedule)
+
     job = context.job_queue.run_repeating(
         create_poll,
         interval=timedelta(weeks=1),
-        first=upcoming_scheduled_date.replace(hour=20, minute=0, second=0),
+        first=datetime(
+            upcoming_scheduled_date.year,
+            upcoming_scheduled_date.month,
+            upcoming_scheduled_date.day,
+            20,
+            0,
+            0,
+        ),
         context=poll_creation_dto,
         name=job_name,
     )
@@ -71,7 +79,7 @@ def check_if_job_exists(name: str, context: CallbackContext) -> bool:
     return True
 
 
-def is_args_valid(day) -> bool:
+def is_args_valid(day: str) -> bool:
     """ Validates that the supplied arg is a valid day """
     if day.lower() not in [
         "monday",
@@ -86,7 +94,7 @@ def is_args_valid(day) -> bool:
     return True
 
 
-def create_poll(context: CallbackContext):
+def create_poll(context: CallbackContext) -> None:
     """ Creates a new poll by calling /neweventcommand """
     _logger.debug("Poll creation is triggered by timer on %s", datetime.now())
     create_new_poll(context.job.context["update"], context.job.context["context"])

--- a/ongabot/handler/schedulecommand.py
+++ b/ongabot/handler/schedulecommand.py
@@ -10,49 +10,57 @@ from utils.log import log
 
 _logger = logging.getLogger(__name__)
 
+
 class ScheduleCommandHandler(CommandHandler):
     """ Handler for /schedule command """
+
     def __init__(self):
         CommandHandler.__init__(self, "schedule", callback=callback)
+
 
 @log
 def callback(update: Update, context: CallbackContext):
     """ Schedule a poll creation job to run every week """
     job_name = "Weekly scheduled poll creation job"
-    day_to_schedule = 'sunday'
+    day_to_schedule = "sunday"
     _logger.debug("update:\n%s", update)
 
     if check_if_job_exists(job_name, context):
-        update.message.reply_text('Scheduled job already exists. '
-                                  'Send /deschedule first if you wish to create a new scheduled job')
+        update.message.reply_text(
+            "Scheduled job already exists. "
+            "Send /deschedule first if you wish to create a new scheduled job"
+        )
         return
 
     if len(context.args) > 1:
-        update.message.reply_text('Only one argument supported `/schedule <day>[OPTIONAL]`\n\n'
-                                  'Example:\n`/schedule` to schedule job on sundays \(default\)\n'
-                                  '`/schedule monday` to schedule job on mondays',
-                                  parse_mode='MarkdownV2')
+        update.message.reply_text(
+            "Only one argument supported `/schedule <day>[OPTIONAL]`\n\n"
+            "Example:\n`/schedule` default to schedule job on sundays \n"
+            "`/schedule monday` to schedule job on mondays",
+            parse_mode="MarkdownV2",
+        )
         return
 
     if len(context.args) == 1:
         if not is_args_valid(context.args[0]):
-            update.message.reply_text('Please provide a day that I understand. Bitch.')
+            update.message.reply_text("Please provide a day that I understand. Bitch.")
             return
         day_to_schedule = context.args[0]
 
-    poll_creation_dto = {
-        "context": context,
-        "update": update
-    }
+    poll_creation_dto = {"context": context, "update": update}
 
     upcoming_scheduled_date = helper.get_upcoming_date(datetime.now(), day_to_schedule)
-    job = context.job_queue.run_repeating(create_poll,
-                                          interval=timedelta(weeks=1),
-                                          first=upcoming_scheduled_date.replace(hour=20, minute=0, second=0),
-                                          context=poll_creation_dto,
-                                          name=job_name)
+    job = context.job_queue.run_repeating(
+        create_poll,
+        interval=timedelta(weeks=1),
+        first=upcoming_scheduled_date.replace(hour=20, minute=0, second=0),
+        context=poll_creation_dto,
+        name=job_name,
+    )
     update.message.reply_text(
-        f"Poll creation is now scheduled to run every {day_to_schedule} starting on {job.next_t:%Y-%m-%d %H:%M} ({job.next_t.tzinfo})")
+        f"Poll creation is now scheduled to run every {day_to_schedule} "
+        f"starting on {job.next_t:%Y-%m-%d %H:%M} ({job.next_t.tzinfo})"
+    )
 
 
 def check_if_job_exists(name: str, context: CallbackContext) -> bool:
@@ -65,9 +73,18 @@ def check_if_job_exists(name: str, context: CallbackContext) -> bool:
 
 def is_args_valid(day) -> bool:
     """ Validates that the supplied arg is a valid day """
-    if day.lower() not in ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']:
+    if day.lower() not in [
+        "monday",
+        "tuesday",
+        "wednesday",
+        "thursday",
+        "friday",
+        "saturday",
+        "sunday",
+    ]:
         return False
     return True
+
 
 def create_poll(context: CallbackContext):
     logger = context.job.context["logger"]

--- a/ongabot/handler/schedulecommand.py
+++ b/ongabot/handler/schedulecommand.py
@@ -1,0 +1,75 @@
+"""This module contains the ScheduleCommandHandler class."""
+import logging
+from telegram import Update
+from telegram.ext import CommandHandler, CallbackContext
+from .neweventcommand import callback as create_new_poll
+from datetime import datetime, timedelta
+
+import utils.helper as helper
+from utils.log import log
+
+_logger = logging.getLogger(__name__)
+
+class ScheduleCommandHandler(CommandHandler):
+    """ Handler for /schedule command """
+    def __init__(self):
+        CommandHandler.__init__(self, "schedule", callback=callback)
+
+@log
+def callback(update: Update, context: CallbackContext):
+    """ Schedule a poll creation job to run every week """
+    job_name = "Weekly scheduled poll creation job"
+    day_to_schedule = 'sunday'
+    _logger.debug("update:\n%s", update)
+
+    if check_if_job_exists(job_name, context):
+        update.message.reply_text('Scheduled job already exists. '
+                                  'Send /deschedule first if you wish to create a new scheduled job')
+        return
+
+    if len(context.args) > 1:
+        update.message.reply_text('Only one argument supported `/schedule <day>[OPTIONAL]`\n\n'
+                                  'Example:\n`/schedule` to schedule job on sundays \(default\)\n'
+                                  '`/schedule monday` to schedule job on mondays',
+                                  parse_mode='MarkdownV2')
+        return
+
+    if len(context.args) == 1:
+        if not is_args_valid(context.args[0]):
+            update.message.reply_text('Please provide a day that I understand. Bitch.')
+            return
+        day_to_schedule = context.args[0]
+
+    poll_creation_dto = {
+        "context": context,
+        "update": update
+    }
+
+    upcoming_scheduled_date = helper.get_upcoming_date(datetime.now(), day_to_schedule)
+    job = context.job_queue.run_repeating(create_poll,
+                                          interval=timedelta(weeks=1),
+                                          first=upcoming_scheduled_date.replace(hour=20, minute=0, second=0),
+                                          context=poll_creation_dto,
+                                          name=job_name)
+    update.message.reply_text(
+        f"Poll creation is now scheduled to run every {day_to_schedule} starting on {job.next_t:%Y-%m-%d %H:%M} ({job.next_t.tzinfo})")
+
+
+def check_if_job_exists(name: str, context: CallbackContext) -> bool:
+    """ Returns true of false whether job already exists."""
+    current_jobs = context.job_queue.get_jobs_by_name(name)
+    if not current_jobs:
+        return False
+    return True
+
+
+def is_args_valid(day: str) -> bool:
+    """ Validates that the supplied arg is a valid day """
+    if day.lower() not in ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']:
+        return False
+    return True
+
+def create_poll(context: CallbackContext):
+    """ Calls the neweventcommand to create poll"""
+    _logger.debug(f"Poll creation is triggered by timer on {datetime.now()}")
+    create_new_poll(context.job.context["update"], context.job.context["context"])

--- a/ongabot/handler/schedulecommand.py
+++ b/ongabot/handler/schedulecommand.py
@@ -88,5 +88,5 @@ def is_args_valid(day) -> bool:
 
 def create_poll(context: CallbackContext):
     logger = context.job.context["logger"]
-    logger.debug(f"Poll creation is triggered by timer on {datetime.now(tz=timezone.utc)}")
+    logger.debug(f"Poll creation is triggered by timer on {datetime.now()}")
     create_new_poll(context.job.context["update"], context.job.context["context"])

--- a/ongabot/handler/schedulecommand.py
+++ b/ongabot/handler/schedulecommand.py
@@ -63,13 +63,13 @@ def check_if_job_exists(name: str, context: CallbackContext) -> bool:
     return True
 
 
-def is_args_valid(day: str) -> bool:
+def is_args_valid(day) -> bool:
     """ Validates that the supplied arg is a valid day """
     if day.lower() not in ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']:
         return False
     return True
 
 def create_poll(context: CallbackContext):
-    """ Calls the neweventcommand to create poll"""
-    _logger.debug(f"Poll creation is triggered by timer on {datetime.now()}")
+    logger = context.job.context["logger"]
+    logger.debug(f"Poll creation is triggered by timer on {datetime.now(tz=timezone.utc)}")
     create_new_poll(context.job.context["update"], context.job.context["context"])

--- a/ongabot/handler/schedulecommand.py
+++ b/ongabot/handler/schedulecommand.py
@@ -1,12 +1,12 @@
 """This module contains the ScheduleCommandHandler class."""
 import logging
+from datetime import datetime, timedelta
 from telegram import Update
 from telegram.ext import CommandHandler, CallbackContext
-from .neweventcommand import callback as create_new_poll
-from datetime import datetime, timedelta
-
-import utils.helper as helper
 from utils.log import log
+import utils.helper as helper
+from .neweventcommand import callback as create_new_poll
+
 
 _logger = logging.getLogger(__name__)
 
@@ -87,6 +87,6 @@ def is_args_valid(day) -> bool:
 
 
 def create_poll(context: CallbackContext):
-    logger = context.job.context["logger"]
-    logger.debug(f"Poll creation is triggered by timer on {datetime.now()}")
+    """ Creates a new poll by calling /neweventcommand """
+    _logger.debug("Poll creation is triggered by timer on %s", datetime.now())
     create_new_poll(context.job.context["update"], context.job.context["context"])

--- a/ongabot/handler/schedulecommandhandler.py
+++ b/ongabot/handler/schedulecommandhandler.py
@@ -6,16 +6,17 @@ from typing import Any
 
 from telegram import Update
 from telegram.ext import CommandHandler, CallbackContext
+
+from utils import helper
 from utils.log import log
-import utils.helper as helper
-from .neweventcommand import callback as create_new_poll
+from .neweventcommandhandler import callback as create_new_poll
 
 
 _logger = logging.getLogger(__name__)
 
 
 class ScheduleCommandHandler(CommandHandler):
-    """ Handler for /schedule command """
+    """Handler for /schedule command"""
 
     def __init__(self) -> None:
         CommandHandler.__init__(self, "schedule", callback=callback)
@@ -23,7 +24,7 @@ class ScheduleCommandHandler(CommandHandler):
 
 @log
 def callback(update: Update, context: CallbackContext) -> None:
-    """ Schedule a poll creation job to run every week """
+    """Schedule a poll creation job to run every week"""
     job_name = "Weekly scheduled poll creation job"
     day_to_schedule = "sunday"
     _logger.debug("update:\n%s", update)
@@ -75,7 +76,7 @@ def callback(update: Update, context: CallbackContext) -> None:
 
 
 def check_if_job_exists(name: str, context: CallbackContext) -> bool:
-    """ Returns true of false whether job already exists."""
+    """Returns true of false whether job already exists."""
     current_jobs = context.job_queue.get_jobs_by_name(name)
     if not current_jobs:
         return False
@@ -83,7 +84,7 @@ def check_if_job_exists(name: str, context: CallbackContext) -> bool:
 
 
 def is_args_valid(day: str) -> bool:
-    """ Validates that the supplied arg is a valid day """
+    """Validates that the supplied arg is a valid day"""
     if day.lower() not in [
         "monday",
         "tuesday",
@@ -98,7 +99,7 @@ def is_args_valid(day: str) -> bool:
 
 
 def create_poll(context: CallbackContext) -> None:
-    """ Creates a new poll by calling /neweventcommand """
+    """Creates a new poll by calling /neweventcommand"""
     _logger.debug("Poll creation is triggered by timer on %s", datetime.now())
     create_new_poll(
         typing.cast(typing.Dict[str, Any], context.job.context)["update"],

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -13,6 +13,7 @@ from handler import NewEventCommandHandler
 from handler import CancelEventCommandHandler
 from handler import OngaCommandHandler
 from handler import StartCommandHandler
+from handler import ScheduleCommandHandler
 
 
 logging.basicConfig(
@@ -42,6 +43,7 @@ def main() -> None:
     dispatcher.add_handler(CancelEventCommandHandler())
     dispatcher.add_handler(EventPollHandler())
     dispatcher.add_handler(EventPollAnswerHandler())
+    dispatcher.add_handler(ScheduleCommandHandler())
     dispatcher.add_error_handler(error)
 
     # Start the bot

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -14,6 +14,7 @@ from handler import CancelEventCommandHandler
 from handler import OngaCommandHandler
 from handler import StartCommandHandler
 from handler import ScheduleCommandHandler
+from handler import DeScheduleCommandHandler
 
 
 logging.basicConfig(
@@ -44,6 +45,7 @@ def main() -> None:
     dispatcher.add_handler(EventPollHandler())
     dispatcher.add_handler(EventPollAnswerHandler())
     dispatcher.add_handler(ScheduleCommandHandler())
+    dispatcher.add_handler(DeScheduleCommandHandler())
     dispatcher.add_error_handler(error)
 
     # Start the bot

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -19,6 +19,9 @@ def create_help_text() -> str:
         "/onga - This is the way, let me show you\n"
         "/newevent - Create a new event corresponding to upcoming Wednesday and pins it\n"
         "/cancelevent - Cancels the latest default event, i.e. unpins it\n"
+        "/schedule <day>[OPTIONAL] - Schedules a job to create a poll on every upcoming <day>. If no argument is supplied, job"
+        " is scheduled to run on sundays\n"
+        "/deschedule - Deschedules jobs"
     )
 
     return text

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -29,7 +29,7 @@ def create_help_text() -> str:
 
 
 def get_upcoming_date(today: date, upcoming_weekday: str) -> date:
-    """Get the date of the next upcoming day with name upcoming_weekday """
+    """Get the date of the next upcoming day with name upcoming_weekday"""
     index = get_weekday_index_from_name(upcoming_weekday)
 
     next_date = today + timedelta((index - today.weekday()) % 7)
@@ -37,7 +37,7 @@ def get_upcoming_date(today: date, upcoming_weekday: str) -> date:
 
 
 def get_weekday_index_from_name(day_name: str) -> int:
-    """ Get the day index from week day name """
+    """Get the day index from week day name"""
     return {
         "monday": 0,
         "tuesday": 1,

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -1,5 +1,5 @@
 """This module contains helper functions."""
-from datetime import datetime, date, timedelta
+from datetime import date, timedelta
 
 
 def create_help_text() -> str:
@@ -28,7 +28,7 @@ def create_help_text() -> str:
     return text
 
 
-def get_upcoming_date(today: datetime, upcoming_weekday: str) -> date:
+def get_upcoming_date(today: date, upcoming_weekday: str) -> date:
     """Get the date of the next upcoming day with name upcoming_weekday """
     index = get_weekday_index_from_name(upcoming_weekday)
 

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -1,5 +1,5 @@
 """This module contains helper functions."""
-from datetime import date, timedelta
+from datetime import datetime, date, timedelta
 
 
 def create_help_text() -> str:
@@ -24,9 +24,22 @@ def create_help_text() -> str:
     return text
 
 
-def get_upcoming_wednesday_date(today: date) -> date:
-    """Get the date of the next upcoming wednesday"""
-    wednesday_day_of_week_index = 2  # 0-6, 0 is monday and 6 is sunday
-    next_wednesday_date = today + timedelta((wednesday_day_of_week_index - today.weekday()) % 7)
+def get_upcoming_date(today: datetime, upcoming_weekday: str) -> date:
+    """Get the date of the next upcoming day with name upcoming_weekday """
+    index = get_weekday_index_from_name(upcoming_weekday)
 
-    return next_wednesday_date
+    next_date = today + timedelta((index - today.weekday()) % 7)
+    return next_date
+
+
+def get_weekday_index_from_name(day_name: str) -> int:
+    """ Get the day index from week day name """
+    return {
+        'monday': 0,
+        'tuesday': 1,
+        'wednesday': 2,
+        'thursday': 3,
+        'friday': 4,
+        'saturday': 5,
+        'sunday': 6
+    }[day_name.lower()]

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -19,7 +19,8 @@ def create_help_text() -> str:
         "/onga - This is the way, let me show you\n"
         "/newevent - Create a new event corresponding to upcoming Wednesday and pins it\n"
         "/cancelevent - Cancels the latest default event, i.e. unpins it\n"
-        "/schedule <day>[OPTIONAL] - Schedules a job to create a poll on every upcoming <day>. If no argument is supplied, job"
+        "/schedule <day>[OPTIONAL] - Schedules a job to create a poll on "
+        "every upcoming <day>. If no argument is supplied, job"
         " is scheduled to run on sundays\n"
         "/deschedule - Deschedules jobs"
     )
@@ -38,11 +39,11 @@ def get_upcoming_date(today: datetime, upcoming_weekday: str) -> date:
 def get_weekday_index_from_name(day_name: str) -> int:
     """ Get the day index from week day name """
     return {
-        'monday': 0,
-        'tuesday': 1,
-        'wednesday': 2,
-        'thursday': 3,
-        'friday': 4,
-        'saturday': 5,
-        'sunday': 6
+        "monday": 0,
+        "tuesday": 1,
+        "wednesday": 2,
+        "thursday": 3,
+        "friday": 4,
+        "saturday": 5,
+        "sunday": 6,
     }[day_name.lower()]

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -15,7 +15,7 @@ class HelperTest(unittest.TestCase):
         ]
     )
     def test_getUpcomingWednesdayDate(self, _, today, expected):
-        result = helper.get_upcoming_wednesday_date(today)
+        result = helper.get_upcoming_date(today, "wednesday")
         self.assertEqual(
             result.weekday(),
             2,


### PR DESCRIPTION
 Fixes #21. Two new commands

# /schedule
 `/schedule ` - Add scheduled job to job_queue. The actual job is a call the `/neweventcommand` callback function to create a new poll. Defaults to sunday evening at 20:00 UTC (bot's default timezone). 

Can be passed with optional day parameter, e.g. `/schedule thursday` to schedule jobs on thursdays. 

# /deschedule
`/deschedule` - Removes job from job_queue. 


## Note!
Persistence is not working. This should be done in #47.