### PR TITLE
Make event creation flexible with day/time/slots args (#277)

### DIFF
--- a/ongabot/botdata.py
+++ b/ongabot/botdata.py
@@ -1,7 +1,7 @@
 """This module contains the BotData class."""
 
 import logging
-from typing import Callable, Dict, Set
+from typing import Callable, Dict, Optional, Set
 
 from telegram.ext import JobQueue
 
@@ -29,7 +29,10 @@ class BotData:
 
     def __setstate__(self, state: Dict) -> None:
         self.__dict__.update(state)
+        # Set default values for any missing attributes (for backward compatibility with older persisted data)
         if not hasattr(self, "authorized_chats"):
+            # Old chats are not authorized by default, to avoid accidentally authorizing all existing chats
+            # when deploying the bot with persistence for the first time
             self.authorized_chats = set()
 
     def __repr__(self) -> str:
@@ -38,14 +41,16 @@ class BotData:
     @log.method
     def get_chat(self, chat_id: int) -> Chat:
         """Get a Chat from BotData, and if it doesnt exist create it"""
-        if not self.chats.get(chat_id):
+        chat = self.chats.get(chat_id)
+        if not chat:
             # Create a Chat object for chat_id if not found
-            self.chats.update({chat_id: Chat(chat_id)})
+            chat = Chat(chat_id)
+            self.chats.update({chat_id: chat})
 
-        return self.chats.get(chat_id)
+        return chat
 
     @log.method
-    def get_event(self, poll_id: str) -> Event:
+    def get_event(self, poll_id: str) -> Optional[Event]:
         """Get an event from BotData"""
         for chat in self.chats.values():
             event = chat.get_event(poll_id)

--- a/ongabot/chat.py
+++ b/ongabot/chat.py
@@ -1,7 +1,8 @@
 """This module contains the Chat class."""
 
 import logging
-from typing import Callable, Dict
+from datetime import date
+from typing import Callable, Dict, Optional
 
 from telegram import Message
 from telegram.error import TelegramError
@@ -25,76 +26,100 @@ class Chat:
         chat_id: id of the chat the data belongs to
         events: dictionary of Event objects indexed on poll_id
         event_job: EventJob if there is one scheduled for the chat, otherwise None
-        pinned_poll: telegram.Message of a pinned event poll message if any, otherwise None
+        pinned_polls: dict of pinned event poll messages indexed on poll_id
     """
 
     def __init__(self, chat_id: int) -> None:
         self.chat_id = chat_id
 
         self.events: Dict[str, Event] = {}
-        self.event_job: EventJob = None
-        self.pinned_poll: Message = None
+        self.event_job: Optional[EventJob] = None
+        self.pinned_polls: Dict[str, Message] = {}
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        # Set default values for any missing attributes (for backward compatibility with older persisted data)
+        if not hasattr(self, "pinned_polls"):
+            old = self.__dict__.pop("pinned_poll", None)
+            self.pinned_polls = {}
+            if old is not None:
+                try:
+                    self.pinned_polls[old.poll.id] = old
+                except AttributeError:
+                    pass  # old message had no .poll; discard silently
+
+        # Remove old pinned_poll attribute if it exists, to avoid confusion and save memory
+        self.__dict__.pop("pinned_poll", None)
 
     def __repr__(self) -> str:
         return str(self.__class__) + ": " + str(self.__dict__)
 
+    @property
+    def active_events(self) -> list[Event]:
+        """Return a list of active (not completed) events."""
+        return [e for e in self.events.values() if not e.completed]
+
+    def find_active_event(self, target_date: date) -> list[Event]:
+        """Return active events matching target_date."""
+        return [e for e in self.active_events if e.event_date == target_date]
+
     @log.method
     def add_event(self, event: Event) -> bool:
-        """Add an Event to BotData"""
+        """Add an Event"""
         if self.events.get(event.poll_id):
-            _logger.error("Event with poll_id=%s already exist in BotData!", event.poll_id)
+            _logger.error("Event with poll_id=%s already exist!", event.poll_id)
             return False
 
         self.events.update({event.poll_id: event})
         return True
 
     @log.method
-    def get_event(self, poll_id: str) -> Event:
-        """Get an event from BotData"""
+    def get_event(self, poll_id: str) -> Optional[Event]:
+        """Get an event"""
 
         if not self.events.get(poll_id):
-            _logger.error("Event with poll_id=%s doesn't exist in BotData!", poll_id)
+            _logger.error("Event with poll_id=%s doesn't exist!", poll_id)
             return None
 
         return self.events.get(poll_id)
 
     @log.method
-    def set_pinned_poll(self, message: Message) -> bool:
-        """Set a pinned event poll message for the chat"""
-        if self.pinned_poll:
-            _logger.error("pinned_poll=%s already exist when adding=%s", self.pinned_poll, message)
+    def set_pinned_poll(self, poll_id: str, message: Message) -> bool:
+        """Register a pinned poll message for a given poll_id"""
+        if poll_id in self.pinned_polls:
+            _logger.error(
+                "pinned_poll for poll_id=%s already exists when adding message_id=%s",
+                poll_id,
+                message.message_id,
+            )
             return False
 
-        self.pinned_poll = message
+        self.pinned_polls[poll_id] = message
         return True
 
     @log.method
-    def get_pinned_poll(self) -> Message:
-        """Get the pinned event poll message"""
-        return self.pinned_poll
-
-    @log.method
-    async def remove_pinned_poll(self) -> None:
-        """Remove the pinned event poll message"""
-        if not self.pinned_poll:
-            _logger.warning("Trying to remove pinned_poll=None")
+    async def remove_pinned_poll(self, poll_id: str) -> None:
+        """Unpin and remove the pinned event poll message for a given poll_id"""
+        message = self.pinned_polls.get(poll_id)
+        if message is None:
+            _logger.warning("Trying to remove pinned_poll for unknown poll_id=%s", poll_id)
             return
 
         try:
-            await self.pinned_poll.unpin()
+            await message.unpin()
         except TelegramError:
             _logger.warning(
-                "Failed trying to unpin message (message_id=%i).", self.pinned_poll.message_id
+                "Failed trying to unpin message_id=%i for poll_id=%s",
+                message.message_id,
+                poll_id,
             )
-        self.pinned_poll = None
+        del self.pinned_polls[poll_id]
 
     @log.method
     def set_event_job(self, event_job: EventJob) -> bool:
         """Set an event job for the chat"""
         if self.event_job:
-            _logger.error(
-                "job_name=%s already exist Chat with chat_id=%s!", event_job.job_name, self.chat_id
-            )
+            _logger.error("job_name=%s already exist Chat with chat_id=%s!", event_job.job_name, self.chat_id)
             return False
 
         self.event_job = event_job

--- a/ongabot/event.py
+++ b/ongabot/event.py
@@ -1,13 +1,15 @@
 """This module contains the Event class."""
 
 import logging
-from typing import Dict
+from datetime import date, time
+from typing import Dict, Optional
 
 
 from telegram import Bot, Poll, PollAnswer, User
 from telegram.constants import ParseMode
 from telegram.helpers import escape_markdown
 
+from eventdata import EventData
 from utils import log
 
 _logger = logging.getLogger(__name__)
@@ -20,6 +22,7 @@ class Event:
     Args:
         chat_id: id of the chat the event belongs to
         poll: initial telegram.Poll related to the event
+        data: date, start time, and slot count for this event
 
     Attributes:
         chat_id: id of the chat the event belongs to
@@ -27,17 +30,46 @@ class Event:
         poll_id: id of the poll object
         poll_answers: dict of users and their answers to the poll
         status_message_id: id of the status message for the event
+        data: EventData grouping event_date, start_time, num_slots
+        completed: whether the event is complete (date has passed or was cancelled)
     """
 
-    def __init__(self, chat_id: int, poll: Poll) -> None:
+    def __init__(self, chat_id: int, poll: Poll, data: EventData) -> None:
         self.chat_id = chat_id
         self.poll = poll
-
         self.poll_id = poll.id
-
         self.poll_answers: Dict[User, PollAnswer] = {}
-        self.first_answer: User = None
+        self.first_answer: Optional[User] = None
         self.status_message_id = 0
+        self.data: EventData = data
+        self.completed: bool = False
+
+    @property
+    def event_date(self) -> date:
+        """Date of this event."""
+        return self.data.event_date
+
+    @property
+    def start_time(self) -> time:
+        """Start time of the first poll option."""
+        return self.data.start_time
+
+    @property
+    def num_slots(self) -> int:
+        """Number of 40-min time slots in the poll."""
+        return self.data.num_slots
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        # Set default values for any missing attributes (for backward compatibility with older persisted data)
+        if not hasattr(self, "data"):
+            # date.min treated as already past, so that old events will be marked completed immediately on update
+            # and not show up as active events, otherwise assume default values for all fields
+            self.data = EventData(date.min)
+        if not hasattr(self, "completed"):
+            # Assume old events are completed, aligned with date.min, to avoid showing them as active events after
+            # a bot update
+            self.completed = True
 
     def __repr__(self) -> str:
         return str(self.__class__) + ": " + str(self.__dict__)
@@ -65,12 +97,19 @@ class Event:
         )
 
     @log.method
+    def mark_complete(self) -> None:
+        """Mark this event as completed (date has passed or was cancelled)"""
+        self.completed = True
+
+    @log.method
     def _create_status_message_text(self, chat_member_count: int) -> str:
         """Create formatted status message text for the event poll"""
-        # total minus (voters + 'me, the bot')
-        no_vote_count = chat_member_count - (self.poll.total_voter_count + 1)
-
-        message = f"*__Currently {no_vote_count} non\\-voting infidels\\!__*\n"
+        if self.completed:
+            message = "*__Event complete\\!__*\n"
+        else:
+            # total minus (voters + 'me, the bot')
+            no_vote_count = chat_member_count - (self.poll.total_voter_count + 1)
+            message = f"*__Currently {no_vote_count} non\\-voting infidels\\!__*\n"
 
         if self.first_answer:
             message += "\n*Honerable mention, first newb to the poll box:* "
@@ -94,6 +133,10 @@ class Event:
     @log.method
     def update_answer(self, poll_answer: PollAnswer) -> None:
         """Update, or add, an answer for a specific user"""
+        if poll_answer.user is None:
+            _logger.warning("Attempted to update answer for user with None ID")
+            return
+
         if self.first_answer is None:
             self.first_answer = poll_answer.user
 

--- a/ongabot/eventcreator.py
+++ b/ongabot/eventcreator.py
@@ -1,13 +1,13 @@
 """This module contains the helper functions for creating an event."""
 
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, time, timedelta
 
 from telegram.ext import CallbackContext
 
 from chat import Chat
 from event import Event
-from utils import helper
+from eventdata import EventData
 from utils.log import log
 
 _logger = logging.getLogger(__name__)
@@ -17,67 +17,84 @@ _logger = logging.getLogger(__name__)
 async def create_event_callback(context: CallbackContext) -> None:
     """Create the event on callback, after extracting chat_id from job.context"""
     _logger.debug("Poll creation is triggered by timer on %s", datetime.now())
-    await create_event(context, context.job.chat_id)
+    if context.job is None or context.job.chat_id is None:
+        _logger.error("Received event creation callback without job or chat_id in context")
+        return
+
+    chat: Chat = context.bot_data.get_chat(context.job.chat_id)
+    if chat.event_job is None:
+        _logger.error("No event job found for chat_id %s in create_event_callback", context.job.chat_id)
+        return
+
+    await create_event(context, context.job.chat_id, chat.event_job.to_event_data())
 
 
 @log
-async def create_event(context: CallbackContext, chat_id: int) -> None:
+async def create_event(
+    context: CallbackContext,
+    chat_id: int,
+    event_data: EventData,
+) -> None:
     """Create an event"""
-    # Retrieve previous pinned poll message and try to unpin if applicable
     chat: Chat = context.bot_data.get_chat(chat_id)
-    pinned_poll = chat.get_pinned_poll()
 
-    if pinned_poll is not None:
-        next_thu = helper.get_upcoming_date(date.today(), "thursday").strftime("%Y-%m-%d")
-        if next_thu in pinned_poll.poll.question:
+    # Check for an existing active (non-completed) event on the same date
+    for existing in chat.active_events:
+        if existing.event_date == event_data.event_date:
             await context.bot.send_message(
                 chat_id,
-                "Event already exists for: "
-                + next_thu
-                + "\nSend /cancelevent first if you wish to create a new event.",
+                f"Event already exists for: {event_data.event_date}"
+                "\nSend /cancelevent first if you wish to cancel it.",
             )
-            _logger.debug("Event already exist for next Thursday (%s).", next_thu)
+            _logger.debug("Event already exists for date %s.", event_data.event_date)
             return
-
-        await chat.remove_pinned_poll()
 
     poll_message = await context.bot.send_poll(
         chat_id,
-        _create_poll_text(),
-        options=_create_poll_options(),
+        _create_poll_text(event_data.event_date, event_data.start_time),
+        options=_create_poll_options(event_data.start_time, event_data.num_slots),
         is_anonymous=False,
         allows_multiple_answers=True,
     )
     _logger.debug("poll_message:\n%s", poll_message)
 
-    event = Event(chat_id, poll_message.poll)
+    event = Event(chat_id, poll_message.poll, event_data)
     await event.send_status_message(context.bot)
 
     chat.add_event(event)
 
-    # Pin new message and save to chat_data for future removal
+    # Pin new message and save to chat data for future removal
     await poll_message.pin(disable_notification=True)
-    chat.set_pinned_poll(poll_message)
+    chat.set_pinned_poll(poll_message.poll.id, poll_message)
 
 
-def _create_poll_text() -> str:
+_EVENT_NAME_BY_WEEKDAY = {
+    0: "MÅGA",
+    1: "TIGA",
+    2: "ONGA",
+    3: "TOGA",
+    4: "FREGA",
+    5: "LÖGA",
+    6: "SÖGA",
+}
+
+
+def _create_poll_text(event_date: date, start_time: time) -> str:
     """Create text field for poll"""
-    title = "Event: TOGA (with ONGA)"
-    when = f"When: {helper.get_upcoming_date(date.today(), 'thursday')}"
-    text = f"{title}\n{when}"
-    return text
+    name = _EVENT_NAME_BY_WEEKDAY[event_date.weekday()]
+    if event_date.weekday() != 2:  # Onsdag is the home day, no suffix
+        name += " (with ONGA)"
+    title = f"Event: {name}"
+    when = f"When: {event_date} {start_time.strftime('%H:%M')}"
+    return f"{title}\n{when}"
 
 
-def _create_poll_options() -> list[str]:
-    """Create options for poll"""
-    options = [
-        "18.30",
-        "19.10",
-        "19.50",
-        "20.40",
-        "21.20",
-        "No-op",
-        "Maybe Baby </3",
-    ]
-
+def _create_poll_options(start_time: time, num_slots: int) -> list[str]:
+    """Create poll options: num_slots time options at 40-min intervals, then No-op and Maybe Baby"""
+    dt = datetime.combine(date.today(), start_time)
+    options = []
+    for _ in range(num_slots):
+        options.append(dt.strftime("%H.%M"))
+        dt += timedelta(minutes=40)
+    options += ["No-op", "Maybe Baby </3"]
     return options

--- a/ongabot/eventdata.py
+++ b/ongabot/eventdata.py
@@ -1,0 +1,23 @@
+"""This module contains the EventData dataclass."""
+
+from dataclasses import dataclass, field
+from datetime import date, time
+
+from utils import helper
+
+DEFAULT_EVENT_DAY = "wednesday"
+DEFAULT_START_TIME = time(18, 30)
+DEFAULT_NUM_SLOTS = 5
+
+
+def _default_event_date() -> date:
+    return helper.get_upcoming_date(date.today(), DEFAULT_EVENT_DAY)
+
+
+@dataclass
+class EventData:
+    """Groups the concrete date, start time, and slot count that define a single event."""
+
+    event_date: date = field(default_factory=_default_event_date)
+    start_time: time = DEFAULT_START_TIME
+    num_slots: int = DEFAULT_NUM_SLOTS

--- a/ongabot/eventjob.py
+++ b/ongabot/eventjob.py
@@ -1,14 +1,17 @@
 """This module contains the EventJob class."""
 
 import logging
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, time, timedelta
 from typing import Callable
 
 from telegram.ext import Job, JobQueue
 
+from eventdata import DEFAULT_EVENT_DAY, DEFAULT_NUM_SLOTS, DEFAULT_START_TIME, EventData
 from utils import helper, log
 
 _logger = logging.getLogger(__name__)
+
+DEFAULT_TRIGGER_DAY = "sunday"
 
 
 class EventJob:
@@ -17,25 +20,67 @@ class EventJob:
 
     Args:
         chat_id: id of the chat the event belongs to
-        day_to_schedule: weekday to schedule the job on
+        trigger_on: weekday on which to trigger the job (when to create the poll)
+        event_day: weekday the created poll refers to (which day the event is on)
+        start_time: start time for the first poll option
+        num_slots: number of time-slot options in the poll
 
     Attributes:
         chat_id: id of the chat the event belongs to
-        day_to_schedule: weekday to schedule the job on
+        trigger_on: weekday on which to trigger the job
+        event_day: weekday the created poll refers to
+        start_time: start time for the first poll option
+        num_slots: number of time-slot options in the poll
         job_name: name of the job as used in JobQueue
     """
 
-    def __init__(self, chat_id: int, day_to_schedule: str) -> None:
+    def __init__(
+        self,
+        chat_id: int,
+        trigger_on: str = DEFAULT_TRIGGER_DAY,
+        event_day: str = DEFAULT_EVENT_DAY,
+        start_time: time = DEFAULT_START_TIME,
+        num_slots: int = DEFAULT_NUM_SLOTS,
+    ) -> None:
         self.chat_id = chat_id
-        self.day_to_schedule = day_to_schedule
+        self.trigger_on = trigger_on
+        self.event_day = event_day
+        self.start_time = start_time
+        self.num_slots = num_slots
 
-        self.job_name = f"weeky_event_{chat_id}"
+        self.job_name = f"weeky_event_{chat_id}"  # typo preserved for persistence compatibility
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        # Set default values for any missing attributes (for backward compatibility with older persisted data)
+        if not hasattr(self, "trigger_on"):
+            old = self.__dict__.pop("day_to_schedule", None)
+            if old is not None:
+                self.trigger_on = old
+            else:
+                self.trigger_on = DEFAULT_TRIGGER_DAY
+        if not hasattr(self, "event_day"):
+            self.event_day = DEFAULT_EVENT_DAY
+        if not hasattr(self, "start_time"):
+            self.start_time = DEFAULT_START_TIME
+        if not hasattr(self, "num_slots"):
+            self.num_slots = DEFAULT_NUM_SLOTS
 
     @log.method
     def schedule(self, job_queue: JobQueue, callback: Callable) -> Job:
         """Schedule this event job in the provided job_queue"""
-        upcoming_date = helper.get_upcoming_date(date.today(), self.day_to_schedule)
+        upcoming_date = helper.get_upcoming_date(date.today(), self.event_day)
 
+        _logger.info(
+            "Scheduling event job for chat_id=%s on %s (upcoming date: %s) "
+            "with event day %s, start time %s, and %s slots",
+            self.chat_id,
+            self.trigger_on,
+            upcoming_date,
+            self.event_day,
+            self.start_time,
+            self.num_slots,
+        )
         return job_queue.run_repeating(
             callback,
             interval=timedelta(weeks=1),
@@ -56,6 +101,7 @@ class EventJob:
         """Deschedule this event job"""
         current_jobs = job_queue.get_jobs_by_name(self.job_name)
         if not current_jobs:
+            _logger.info("No jobs found to deschedule.")
             return False
 
         for job in current_jobs:
@@ -63,9 +109,7 @@ class EventJob:
         return True
 
     @log.method
-    def check_if_job_exists(self, job_queue: JobQueue) -> bool:
-        """Return true or false whether job already exists in job_queue"""
-        current_jobs = job_queue.get_jobs_by_name(self.job_name)
-        if not current_jobs:
-            return False
-        return True
+    def to_event_data(self) -> EventData:
+        """Build a concrete EventData for the next upcoming occurrence of this job's event day."""
+        event_date = helper.get_upcoming_date(date.today(), self.event_day)
+        return EventData(event_date, self.start_time, self.num_slots)

--- a/ongabot/handler/__init__.py
+++ b/ongabot/handler/__init__.py
@@ -2,28 +2,32 @@
 
 from .authorizationhandler import AuthorizationHandler
 from .authorizecommandhandler import AuthorizeCommandHandler
+from .canceleventcommandhandler import CancelEventCommandHandler
 from .deauthorizecommandhandler import DeAuthorizeCommandHandler
-from .eventpollhandler import EventPollHandler
+from .deschedulecommandhandler import DeScheduleCommandHandler
 from .eventpollanswerhandler import EventPollAnswerHandler
+from .eventpollhandler import EventPollHandler
 from .helpcommandhandler import HelpCommandHandler
 from .neweventcommandhandler import NewEventCommandHandler
-from .canceleventcommandhandler import CancelEventCommandHandler
 from .ongacommandhandler import OngaCommandHandler
-from .startcommandhandler import StartCommandHandler
+from .reschedulecommandhandler import RescheduleCommandHandler
 from .schedulecommandhandler import ScheduleCommandHandler
-from .deschedulecommandhandler import DeScheduleCommandHandler
+from .startcommandhandler import StartCommandHandler
+from .updateeventcommandhandler import UpdateEventCommandHandler
 
 __all__ = (
     "AuthorizationHandler",
     "AuthorizeCommandHandler",
+    "CancelEventCommandHandler",
     "DeAuthorizeCommandHandler",
+    "DeScheduleCommandHandler",
     "EventPollAnswerHandler",
     "EventPollHandler",
     "HelpCommandHandler",
     "NewEventCommandHandler",
-    "CancelEventCommandHandler",
     "OngaCommandHandler",
-    "StartCommandHandler",
+    "RescheduleCommandHandler",
     "ScheduleCommandHandler",
-    "DeScheduleCommandHandler",
+    "StartCommandHandler",
+    "UpdateEventCommandHandler",
 )

--- a/ongabot/handler/authorizationhandler.py
+++ b/ongabot/handler/authorizationhandler.py
@@ -35,7 +35,5 @@ async def callback(update: Update, context: CallbackContext) -> None:
 
     if not context.bot_data.is_authorized(chat.id):
         if msg:
-            await msg.reply_text(
-                "This bot is not enabled for this chat. Contact the bot administrator."
-            )
+            await msg.reply_text("This bot is not enabled for this chat. Contact the bot administrator.")
         raise ApplicationHandlerStop()

--- a/ongabot/handler/canceleventcommandhandler.py
+++ b/ongabot/handler/canceleventcommandhandler.py
@@ -6,9 +6,13 @@ from telegram import Update
 from telegram.ext import CallbackContext, CommandHandler
 
 from chat import Chat
+from utils import helper
+from utils.commands import CANCELEVENT
 from utils.log import log
 
 _logger = logging.getLogger(__name__)
+
+_ALLOWED_ARGS = {"target_date"}
 
 
 class CancelEventCommandHandler(CommandHandler):
@@ -20,12 +24,15 @@ class CancelEventCommandHandler(CommandHandler):
 
 @log
 async def callback(update: Update, context: CallbackContext) -> None:
-    """Cancel active event as result of command /cancelevent"""
-    # Retrieve currently pinned message
-    chat: Chat = context.bot_data.get_chat(update.effective_chat.id)
-    pinned_poll = chat.get_pinned_poll()
+    """Cancel active event as result of command /cancelevent [target_date=<val>]"""
+    if update.effective_chat is None or update.message is None:
+        _logger.warning("Received /cancelevent command with no effective chat or message.")
+        return
 
-    if pinned_poll is None:
+    chat: Chat = context.bot_data.get_chat(update.effective_chat.id)
+    active_events = chat.active_events
+
+    if not active_events:
         await context.bot.send_message(
             update.effective_chat.id,
             "No known event to cancel! Create a new event with /newevent.",
@@ -33,11 +40,52 @@ async def callback(update: Update, context: CallbackContext) -> None:
         _logger.debug("Tried to cancel without existing event.")
         return
 
-    await chat.remove_pinned_poll()
+    target_date = None
+
+    args = context.args or []
+    if args:
+        try:
+            named = helper.parse_named_args(args, _ALLOWED_ARGS)
+        except ValueError as e:
+            await update.message.reply_text(f"{e}\n\n{CANCELEVENT.usage}")
+            return
+        if "target_date" in named:
+            try:
+                target_date = helper.parse_date(named["target_date"])
+            except ValueError as e:
+                await update.message.reply_text(f"{e}\n\n{CANCELEVENT.usage}")
+                return
+
+    candidates = None
+    if target_date:
+        # If target date provided, narrow down candidates to events matching the date
+        candidates = [e for e in active_events if e.event_date == target_date]
+    else:
+        # If no target date provided, consider all active events as candidates for cancellation
+        candidates = active_events
+
+    if not candidates:
+        spec = f" for {target_date}" if target_date else ""
+        await update.message.reply_text(f"No active event found{spec}.")
+        return
+
+    if len(candidates) > 1:
+        lines = ["Multiple active events match. Be more specific using target_date=:"]
+        for e in sorted(candidates, key=lambda e: (e.event_date, e.start_time)):
+            lines.append(f"  • {e.event_date} {e.start_time.strftime('%H:%M')}")
+        lines.append(f"\n{CANCELEVENT.usage}")
+        await context.bot.send_message(update.effective_chat.id, "\n".join(lines))
+        return
+
+    # At this point we have identified a single target event to cancel
+    target_event = candidates[0]
+
+    question = target_event.poll.question.splitlines()[0]
+    target_event.mark_complete()
+    await chat.remove_pinned_poll(target_event.poll_id)
 
     await context.bot.send_message(
         update.effective_chat.id,
-        pinned_poll.poll.question
-        + " \nCancelled successfully. The poll is still accessible in the channel history.",
+        question + "\nCancelled successfully. The poll is still accessible in the channel history.",
     )
-    _logger.debug("Cancelled event with msg id %s", pinned_poll.message_id)
+    _logger.debug("Cancelled event with poll_id %s", target_event.poll_id)

--- a/ongabot/handler/deschedulecommandhandler.py
+++ b/ongabot/handler/deschedulecommandhandler.py
@@ -14,16 +14,18 @@ class DeScheduleCommandHandler(CommandHandler):
     """Handler for /schedule command"""
 
     def __init__(self) -> None:
-        CommandHandler.__init__(self, "deschedule", callback=callback)
+        super().__init__("deschedule", callback=callback)
 
 
 @log
 async def callback(update: Update, context: CallbackContext) -> None:
     """Cancel existing event job in chat"""
+    if update.message is None or update.effective_chat is None or context.job_queue is None:
+        _logger.error("Received /deschedule command without message or effective chat")
+        return
+
     chat: Chat = context.bot_data.get_chat(update.effective_chat.id)
     if not chat.remove_event_job(context.job_queue):
         await update.message.reply_text("No jobs to cancel.")
     else:
-        await update.message.reply_text(
-            "Job cancelled successfully. Polls will no longer be automatically created."
-        )
+        await update.message.reply_text("Job cancelled successfully. Polls will no longer be automatically created.")

--- a/ongabot/handler/eventpollanswerhandler.py
+++ b/ongabot/handler/eventpollanswerhandler.py
@@ -21,9 +21,17 @@ class EventPollAnswerHandler(PollAnswerHandler):
 @log
 async def callback(update: Update, context: CallbackContext) -> None:
     """Handle a poll answer update of an event"""
+    if update.poll_answer is None or update.poll_answer.user is None:
+        _logger.error("Received poll answer update without poll answer")
+        return
+
     event = context.bot_data.get_event(update.poll_answer.poll_id)
     event.update_answer(update.poll_answer)
     await event.update_status_message(context.bot)
+
+    if context.user_data is None:
+        _logger.error("Received poll answer update without user data in context")
+        return
 
     user_data: UserData = context.user_data
     user_data.init_or_update(update.poll_answer.user)

--- a/ongabot/handler/eventpollhandler.py
+++ b/ongabot/handler/eventpollhandler.py
@@ -20,6 +20,10 @@ class EventPollHandler(PollHandler):
 @log
 async def callback(update: Update, context: CallbackContext) -> None:
     """Handle a poll update of an event"""
+    if update.poll is None:
+        _logger.error("Received poll update without poll")
+        return
+
     event = context.bot_data.get_event(update.poll.id)
     event.update_poll(update.poll)
-    event.update_status_message(context.bot)
+    await event.update_status_message(context.bot)

--- a/ongabot/handler/neweventcommandhandler.py
+++ b/ongabot/handler/neweventcommandhandler.py
@@ -6,9 +6,14 @@ from telegram import Update
 from telegram.ext import CallbackContext, CommandHandler
 
 from eventcreator import create_event
+from eventdata import EventData
+from utils import helper
+from utils.commands import NEWEVENT
 from utils.log import log
 
 _logger = logging.getLogger(__name__)
+
+_ALLOWED_ARGS = {"day", "time", "slots"}
 
 
 class NewEventCommandHandler(CommandHandler):
@@ -18,7 +23,34 @@ class NewEventCommandHandler(CommandHandler):
         super().__init__("newevent", callback)
 
 
+def _parse_args(args: list) -> EventData:
+    """Parse named args for /newevent. Raises ValueError with usage on invalid input."""
+    event_data = EventData()
+
+    named = helper.parse_named_args(args, _ALLOWED_ARGS)
+    if "day" in named:
+        event_data.event_date = helper.parse_date(named["day"])
+    if "time" in named:
+        event_data.start_time = helper.parse_time(named["time"])
+    if "slots" in named:
+        event_data.num_slots = helper.parse_num_slots(named["slots"])
+
+    return event_data
+
+
 @log
 async def callback(update: Update, context: CallbackContext) -> None:
-    """Create a poll as result of command /newevent"""
-    await create_event(context, update.effective_chat.id)
+    """Create a poll as result of command /newevent [day=<val>] [time=<HH:MM>] [slots=<n>]"""
+    if update.message is None or update.effective_chat is None:
+        _logger.error("Received /newevent command without message or effective chat")
+        return
+
+    event_data = EventData()
+
+    try:
+        event_data = _parse_args(context.args or [])
+    except ValueError as e:
+        await update.message.reply_text(f"{e}\n\n{NEWEVENT.usage}")
+        return
+
+    await create_event(context, update.effective_chat.id, event_data)

--- a/ongabot/handler/reschedulecommandhandler.py
+++ b/ongabot/handler/reschedulecommandhandler.py
@@ -1,0 +1,79 @@
+"""This module contains the RescheduleCommandHandler class."""
+
+import logging
+
+from telegram import Update
+from telegram.ext import CallbackContext, CommandHandler
+
+from chat import Chat
+from eventcreator import create_event_callback
+from eventjob import EventJob
+from utils import helper
+from utils.commands import RESCHEDULE
+from utils.log import log
+
+_logger = logging.getLogger(__name__)
+
+
+class RescheduleCommandHandler(CommandHandler):
+    """Handler for /reschedule command"""
+
+    def __init__(self) -> None:
+        super().__init__("reschedule", callback)
+
+
+@log
+async def callback(update: Update, context: CallbackContext) -> None:
+    """Update an existing scheduled job as result of command
+    /reschedule [trigger_on=<day>] [day=<day>] [time=<HH:MM>] [slots=<n>]"""
+    if update.message is None or update.effective_chat is None or context.job_queue is None:
+        _logger.error("Received /reschedule command without message or effective chat")
+        return
+
+    chat: Chat = context.bot_data.get_chat(update.effective_chat.id)
+    if not chat.event_job:
+        await update.message.reply_text("No schedule exists. Use /schedule first.")
+        return
+
+    if not context.args:
+        await update.message.reply_text(
+            "At least one of trigger_on/day/time/slots must be provided.\n\n" + RESCHEDULE.usage
+        )
+        return
+
+    try:
+        trigger_on, event_day, start_time, num_slots = helper.parse_event_job_args(
+            context.args,
+            chat.event_job.trigger_on,
+            chat.event_job.event_day,
+            chat.event_job.start_time,
+            chat.event_job.num_slots,
+        )
+    except ValueError as e:
+        await update.message.reply_text(f"{e}\n\n{RESCHEDULE.usage}")
+        return
+
+    if not chat.remove_event_job(context.job_queue):
+        await update.message.reply_text("Failed to remove existing schedule. Try /deschedule first.")
+        return
+    event_job = EventJob(update.effective_chat.id, trigger_on, event_day, start_time, num_slots)
+    job = event_job.schedule(context.job_queue, create_event_callback)
+    chat.set_event_job(event_job)
+
+    if job.next_t is None:
+        _logger.error("Failed to reschedule job for chat_id=%s", update.effective_chat.id)
+        await update.message.reply_text("Failed to reschedule job. Please try again.")
+        return
+
+    _logger.info(
+        "Rescheduled job for chat_id=%s with trigger_on=%s, event_day=%s, start_time=%s, num_slots=%s",
+        update.effective_chat.id,
+        trigger_on,
+        event_day,
+        start_time,
+        num_slots,
+    )
+    await update.message.reply_text(
+        f"Schedule updated: poll fires every {trigger_on}, events for {event_day}. "
+        f"Next trigger on {job.next_t:%Y-%m-%d %H:%M} ({job.next_t.tzinfo})"
+    )

--- a/ongabot/handler/schedulecommandhandler.py
+++ b/ongabot/handler/schedulecommandhandler.py
@@ -3,13 +3,14 @@
 import logging
 
 from telegram import Update
-from telegram.constants import ParseMode
 from telegram.ext import CallbackContext, CommandHandler
 
 from chat import Chat
 from eventcreator import create_event_callback
-from eventjob import EventJob
+from eventdata import DEFAULT_EVENT_DAY, DEFAULT_NUM_SLOTS, DEFAULT_START_TIME
+from eventjob import DEFAULT_TRIGGER_DAY, EventJob
 from utils import helper
+from utils.commands import SCHEDULE
 from utils.log import log
 
 _logger = logging.getLogger(__name__)
@@ -19,51 +20,49 @@ class ScheduleCommandHandler(CommandHandler):
     """Handler for /schedule command"""
 
     def __init__(self) -> None:
-        CommandHandler.__init__(self, "schedule", callback=callback)
+        super().__init__("schedule", callback=callback)
 
 
 @log
 async def callback(update: Update, context: CallbackContext) -> None:
     """Schedule a event creation job to run every week"""
-    if len(context.args) > 1:
-        await update.message.reply_text(
-            "Only one argument supported `/schedule <day>[OPTIONAL]`"
-            "\n\nExample:"
-            "\n`/schedule` default to schedule job on sundays"
-            "\n`/schedule monday` to schedule job on mondays",
-            parse_mode=ParseMode.MARKDOWN_V2,
-        )
+    if update.effective_chat is None or update.message is None or context.job_queue is None:
+        logging.error("Invalid update or missing job queue in ScheduleCommandHandler callback")
         return
-
-    day_to_schedule = "sunday"
-    if len(context.args) == 1:
-        if not helper.is_valid_weekday(context.args[0]):
-            await update.message.reply_text(
-                r"Please provide a day that I understand\. "
-                rf"What even is *__{context.args[0]}__*\?\!"
-                "\n"
-                r"_Bitch\._",
-                parse_mode=ParseMode.MARKDOWN_V2,
-            )
-            return
-        day_to_schedule = context.args[0]
-
-    event_job = EventJob(update.effective_chat.id, day_to_schedule)
-    if event_job.check_if_job_exists(context.job_queue):
-        await update.message.reply_text(
-            r"Scheduled job already exists\. Deschedule first "
-            r"if you wish to re\-create the scheduled job\."
-            "\n`/deschedule`",
-            parse_mode=ParseMode.MARKDOWN_V2,
-        )
-        return
-
-    job = event_job.schedule(context.job_queue, create_event_callback)
 
     chat: Chat = context.bot_data.get_chat(update.effective_chat.id)
+    if chat.event_job:
+        await update.message.reply_text(
+            "Scheduled job already exists. Deschedule first if you wish to re-create it.\n/deschedule"
+        )
+        return
+
+    try:
+        trigger_on, event_day, start_time, num_slots = helper.parse_event_job_args(
+            context.args or [], DEFAULT_TRIGGER_DAY, DEFAULT_EVENT_DAY, DEFAULT_START_TIME, DEFAULT_NUM_SLOTS
+        )
+    except ValueError as e:
+        await update.message.reply_text(f"{e}\n\n{SCHEDULE.usage}")
+        return
+
+    event_job = EventJob(update.effective_chat.id, trigger_on, event_day, start_time, num_slots)
+    job = event_job.schedule(context.job_queue, create_event_callback)
     chat.set_event_job(event_job)
 
+    if job.next_t is None:
+        _logger.error("Failed to schedule job for chat_id=%s", update.effective_chat.id)
+        await update.message.reply_text("Failed to schedule job. Please try again.")
+        return
+
+    _logger.info(
+        "Scheduled job for chat_id=%s with trigger_on=%s, event_day=%s, start_time=%s, num_slots=%s",
+        update.effective_chat.id,
+        trigger_on,
+        event_day,
+        start_time,
+        num_slots,
+    )
     await update.message.reply_text(
-        f"Poll creation is now scheduled to run every {day_to_schedule} "
-        f"starting on {job.next_t:%Y-%m-%d %H:%M} ({job.next_t.tzinfo})"
+        f"Poll creation scheduled every {trigger_on}, events for {event_day}. "
+        f"Starting on {job.next_t:%Y-%m-%d %H:%M} ({job.next_t.tzinfo})"
     )

--- a/ongabot/handler/updateeventcommandhandler.py
+++ b/ongabot/handler/updateeventcommandhandler.py
@@ -1,0 +1,128 @@
+"""This module contains the UpdateEventCommandHandler class."""
+
+import logging
+from datetime import date, time
+from typing import Optional, Tuple
+
+from telegram import Update
+from telegram.ext import CallbackContext, CommandHandler
+
+from chat import Chat
+from eventcreator import create_event
+from eventdata import EventData
+from utils import helper
+from utils.commands import UPDATEEVENT
+from utils.log import log
+
+_logger = logging.getLogger(__name__)
+
+_ALLOWED_ARGS = {"target_date", "day", "time", "slots"}
+
+
+class UpdateEventCommandHandler(CommandHandler):
+    """Handler for /updateevent command"""
+
+    def __init__(self) -> None:
+        super().__init__("updateevent", callback)
+
+
+def _parse_args(args: list) -> Tuple[Optional[date], Optional[date], Optional[time], Optional[int]]:
+    """Parse named args for /updateevent. Raises ValueError with usage on invalid input."""
+    named = helper.parse_named_args(args, _ALLOWED_ARGS)
+
+    target_date: Optional[date] = None
+    new_date: Optional[date] = None
+    new_time: Optional[time] = None
+    new_slots: Optional[int] = None
+
+    if "target_date" in named:
+        try:
+            target_date = helper.parse_date(named["target_date"])
+        except ValueError:
+            raise ValueError(UPDATEEVENT.usage) from None
+    if "day" in named:
+        try:
+            new_date = helper.parse_date(named["day"])
+        except ValueError:
+            raise ValueError(UPDATEEVENT.usage) from None
+    if "time" in named:
+        try:
+            new_time = helper.parse_time(named["time"])
+        except ValueError:
+            raise ValueError(UPDATEEVENT.usage) from None
+    if "slots" in named:
+        try:
+            new_slots = helper.parse_num_slots(named["slots"])
+        except ValueError:
+            raise ValueError(UPDATEEVENT.usage) from None
+
+    if new_date is None and new_time is None and new_slots is None:
+        raise ValueError("At least one of day/time/slots must be provided.\n\n" + UPDATEEVENT.usage)
+
+    return target_date, new_date, new_time, new_slots
+
+
+@log
+async def callback(update: Update, context: CallbackContext) -> None:
+    """Reconfigure an active event as result of command
+    /updateevent [target_date=<val>] [day=<val>] [time=<HH:MM>] [slots=<n>]"""
+    if update.message is None or update.effective_chat is None:
+        _logger.error("Received /updateevent command without message or effective chat")
+        return
+
+    chat: Chat = context.bot_data.get_chat(update.effective_chat.id)
+
+    if not context.args:
+        await update.message.reply_text("Arguments are required to update an event.\n\n" + UPDATEEVENT.usage)
+        return
+
+    try:
+        target_date, new_date, new_time, new_slots = _parse_args(context.args)
+    except ValueError as e:
+        await update.message.reply_text(str(e))
+        return
+
+    candidates = None
+    if target_date is not None:
+        # If target date provided, narrow down candidates to events matching the date
+        candidates = [e for e in chat.active_events if e.event_date == target_date]
+    else:
+        # If no target date provided, consider all active events as candidates for cancellation
+        candidates = chat.active_events
+
+    if not candidates:
+        spec = f" for {target_date}" if target_date else ""
+        await update.message.reply_text(f"No active event found{spec}.")
+        return
+
+    if len(candidates) > 1:
+        lines = ["Multiple active events match. Be more specific using target_date=:"]
+        for e in sorted(candidates, key=lambda e: (e.event_date, e.start_time)):
+            lines.append(f"  • {e.event_date} {e.start_time.strftime('%H:%M')}")
+        lines.append(f"\n{UPDATEEVENT.usage}")
+        await update.message.reply_text("\n".join(lines))
+        return
+
+    # At this point we have identified a single target event to update
+    target_event = candidates[0]
+    update_event_data = EventData(
+        new_date if new_date is not None else target_event.event_date,
+        new_time if new_time is not None else target_event.start_time,
+        new_slots if new_slots is not None else target_event.num_slots,
+    )
+
+    # Validate that the new date doesn't conflict with another active event (except itself)
+    if update_event_data.event_date != target_event.event_date:
+        for event in chat.active_events:
+            if event.event_date == update_event_data.event_date and event is not target_event:
+                await update.message.reply_text(
+                    f"An active event already exists for {update_event_data.event_date}. "
+                    "Cancel it first with /cancelevent."
+                )
+                return
+
+    # Mark the old event complete and create a new one with the merged configuration
+    target_event.mark_complete()
+    await chat.remove_pinned_poll(target_event.poll_id)
+    _logger.info("Cancelled event poll_id=%s for update", target_event.poll_id)
+    await create_event(context, update.effective_chat.id, update_event_data)

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -1,33 +1,79 @@
 #!/usr/bin/env python3
 """An application that runs a telegram bot called ONGAbot"""
 
-import asyncio
+import datetime
 import logging
 import os
 
 from telegram.ext import Application, CallbackContext, ContextTypes, PicklePersistence
 
+import eventcreator
 from botdata import BotData
-from eventcreator import create_event_callback
 from handler import AuthorizationHandler
 from handler import AuthorizeCommandHandler
+from handler import CancelEventCommandHandler
 from handler import DeAuthorizeCommandHandler
+from handler import DeScheduleCommandHandler
 from handler import EventPollAnswerHandler
 from handler import EventPollHandler
 from handler import HelpCommandHandler
 from handler import NewEventCommandHandler
-from handler import CancelEventCommandHandler
 from handler import OngaCommandHandler
-from handler import StartCommandHandler
+from handler import RescheduleCommandHandler
 from handler import ScheduleCommandHandler
-from handler import DeScheduleCommandHandler
+from handler import StartCommandHandler
+from handler import UpdateEventCommandHandler
 from userdata import UserData
+from utils import log
 
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO").upper(),
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
 )
 logger = logging.getLogger(__name__)
+
+
+@log.log
+async def complete_past_events_callback(context: CallbackContext) -> None:
+    """Auto-complete any events whose date has passed: mark complete, update status, unpin poll."""
+    bot_data: BotData = context.bot_data
+    today = datetime.date.today()
+
+    # Iterate through all chats and their events to find and complete past events
+    for chat in bot_data.chats.values():
+        for event in list(chat.events.values()):
+            if not event.completed and event.event_date < today:
+                event.mark_complete()
+                await event.update_status_message(context.bot)
+                await chat.remove_pinned_poll(event.poll_id)
+                logger.info(
+                    "Auto-completed past event poll_id=%s (date=%s) in chat_id=%s",
+                    event.poll_id,
+                    event.event_date,
+                    chat.chat_id,
+                )
+
+
+async def post_init(application: Application) -> None:
+    """Called after the application initializes with persistence loaded."""
+    bot_data: BotData = application.bot_data
+
+    # Seed authorized chats from env var (idempotent; safe to keep in .env)
+    for raw_id in os.getenv("AUTHORIZED_CHAT_IDS", "").split(","):
+        if raw_id.strip().lstrip("-").isdigit():
+            bot_data.authorize_chat(int(raw_id.strip()))
+
+    if application.job_queue is None:
+        logger.error("Job queue is not available in post_init. Event cleanup jobs will not be scheduled.")
+        return
+
+    bot_data.schedule_all_event_jobs(application.job_queue, eventcreator.create_event_callback)
+
+    # Schedule daily cleanup of past events
+    application.job_queue.run_once(complete_past_events_callback, when=5, name="complete_past_events_startup")
+    application.job_queue.run_daily(
+        complete_past_events_callback, time=datetime.time(0, 0, 0), name="complete_past_events"
+    )
 
 
 async def error(update: object, context: CallbackContext) -> None:
@@ -39,15 +85,19 @@ def main() -> None:
     """Setup and run ONGAbot"""
     context_types = ContextTypes(bot_data=BotData, user_data=UserData)
 
-    persistence = PicklePersistence(
-        filepath=os.getenv("DB_PATH", "ongabot.db"), context_types=context_types
-    )
+    persistence = PicklePersistence(filepath=os.getenv("DB_PATH", "ongabot.db"), context_types=context_types)
+
+    api_token = os.getenv("API_TOKEN")
+    if not api_token:
+        logger.error("API_TOKEN environment variable is not set. Exiting.")
+        return
 
     application = (
         Application.builder()
-        .token(os.getenv("API_TOKEN"))
+        .token(api_token)
         .persistence(persistence)
         .context_types(context_types)
+        .post_init(post_init)
         .build()
     )
 
@@ -66,17 +116,9 @@ def main() -> None:
     application.add_handler(EventPollAnswerHandler())
     application.add_handler(ScheduleCommandHandler())
     application.add_handler(DeScheduleCommandHandler())
+    application.add_handler(UpdateEventCommandHandler())
+    application.add_handler(RescheduleCommandHandler())
     application.add_error_handler(error)
-
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    bot_data: BotData = loop.run_until_complete(persistence.get_bot_data())
-    if bot_data:
-        bot_data.schedule_all_event_jobs(application.job_queue, create_event_callback)
-        # Seed authorized chats from env var (idempotent; safe to keep in .env)
-        for raw_id in os.getenv("AUTHORIZED_CHAT_IDS", "").split(","):
-            if raw_id.strip().lstrip("-").isdigit():
-                bot_data.authorize_chat(int(raw_id.strip()))
 
     # Start the bot
     application.run_polling()

--- a/ongabot/userdata.py
+++ b/ongabot/userdata.py
@@ -1,7 +1,7 @@
 """This module contains the UserData class."""
 
 import logging
-from typing import Dict, Tuple
+from typing import Dict, Optional, Tuple
 
 from telegram import User
 
@@ -23,7 +23,7 @@ class UserData:
 
     def __init__(self) -> None:
         self.poll_answer: Dict[str, Tuple[int, ...]] = {}
-        self.user: User = None
+        self.user: Optional[User] = None
 
     def __repr__(self) -> str:
         return str(self.__class__) + ": " + str(self.__dict__)
@@ -34,7 +34,7 @@ class UserData:
         self.user = user
 
     @log.method
-    def get_poll_answer(self, poll_id: str) -> Tuple[int, ...]:
+    def get_poll_answer(self, poll_id: str) -> Optional[Tuple[int, ...]]:
         """Get a PollAnswer for a given poll_id"""
         return self.poll_answer.get(poll_id)
 

--- a/ongabot/utils/commands.py
+++ b/ongabot/utils/commands.py
@@ -1,0 +1,145 @@
+"""Canonical command descriptions and usage strings for all ONGAbot commands.
+
+Handlers import their own USAGE from here; create_help_text() assembles briefs from ALL_COMMANDS.
+This module has no imports from bot code, avoiding circular dependencies.
+"""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class CommandInfo:
+    """
+    Simple struct to hold command info for help text and usage instructions.
+    """
+
+    command: str
+    brief: str  # one-liner shown in /help
+    usage: str  # multi-line shown on bad input
+
+
+HELP = CommandInfo(
+    command="help",
+    brief="/help - Get some aid in needing times",
+    usage="/help",
+)
+
+ONGA = CommandInfo(
+    command="onga",
+    brief="/onga - This is the way, let me show you",
+    usage="/onga",
+)
+
+NEWEVENT = CommandInfo(
+    command="newevent",
+    brief="/newevent [day=<date|weekday>] [time=<HH:MM>] [slots=<n>] - "
+    "Create a new event poll (defaults: wednesday, 18:30, 5 slots)",
+    usage=(
+        "Usage: /newevent [day=<date|weekday>] [time=<HH:MM>] [slots=<n>]\n"
+        "  day: weekday name (next occurrence), YYYY-MM-DD, or dd.mm.yyyy (default: wednesday)\n"
+        "  time: start time of first slot, e.g. 18:30 (default: 18:30)\n"
+        "  slots: number of 40-min time slots (default: 5)\n\n"
+        "Examples:\n"
+        "  /newevent\n"
+        "  /newevent day=friday\n"
+        "  /newevent day=friday time=19:00 slots=3"
+    ),
+)
+
+CANCELEVENT = CommandInfo(
+    command="cancelevent",
+    brief="/cancelevent [target_date=<date|weekday>] - Cancel an active event",
+    usage=(
+        "Usage: /cancelevent [target_date=<date|weekday>]\n"
+        "  Specify target_date if multiple events are active.\n"
+        "  Accepts: weekday name (next occurrence), YYYY-MM-DD, or dd.mm.yyyy\n\n"
+        "Examples:\n"
+        "  /cancelevent\n"
+        "  /cancelevent target_date=wednesday\n"
+        "  /cancelevent target_date=2026-05-10"
+    ),
+)
+
+UPDATEEVENT = CommandInfo(
+    command="updateevent",
+    brief="/updateevent [target_date=<date|weekday>] [day=<date|weekday>] [time=<HH:MM>] [slots=<n>]"
+    " - Update an active event",
+    usage=(
+        "Usage: /updateevent [target_date=<date|weekday>] [day=<date|weekday>] [time=<HH:MM>] [slots=<n>]\n"
+        "  Unspecified args are unchanged.\n"
+        "  target_date: select event by its current date (required if multiple events are active)\n"
+        "  day: new event date — weekday name (next occurrence), YYYY-MM-DD, or dd.mm.yyyy\n"
+        "  time: new start time, e.g. 20:00\n"
+        "  slots: new number of 40-min slots\n"
+        "  At least one of day/time/slots must be provided.\n\n"
+        "Examples:\n"
+        "  /updateevent time=20:00\n"
+        "  /updateevent target_date=2026-05-07 day=2026-05-14\n"
+        "  /updateevent target_date=2026-05-07 time=20:00 slots=4"
+    ),
+)
+
+SCHEDULE = CommandInfo(
+    command="schedule",
+    brief="/schedule [trigger_on=<weekday>] [day=<weekday>] [time=<HH:MM>] [slots=<n>]"
+    " - Schedule weekly poll creation (defaults: sunday → wednesday, 18:30, 5 slots)",
+    usage=(
+        "Usage: /schedule [trigger_on=<day>] [day=<day>] [time=<HH:MM>] [slots=<n>]\n"
+        "  trigger_on: weekday to trigger poll creation (default: sunday)\n"
+        "  day: weekday the poll refers to (default: wednesday)\n"
+        "  time: start time of first slot (default: 18:30)\n"
+        "  slots: number of 40-min time slots (default: 5)\n\n"
+        "Examples:\n"
+        "  /schedule\n"
+        "  /schedule trigger_on=sunday day=wednesday\n"
+        "  /schedule trigger_on=sunday day=wednesday time=19:00 slots=4"
+    ),
+)
+
+RESCHEDULE = CommandInfo(
+    command="reschedule",
+    brief="/reschedule [trigger_on=<weekday>] [day=<weekday>] [time=<HH:MM>] [slots=<n>] - Update the weekly schedule",
+    usage=(
+        "Usage: /reschedule [trigger_on=<day>] [day=<day>] [time=<HH:MM>] [slots=<n>]\n"
+        "  Unspecified args inherit from the current schedule.\n"
+        "  trigger_on: weekday to trigger poll creation\n"
+        "  day: weekday the poll refers to\n"
+        "  time: start time of first slot\n"
+        "  slots: number of 40-min time slots\n\n"
+        "Examples:\n"
+        "  /reschedule time=20:00\n"
+        "  /reschedule trigger_on=monday day=thursday"
+    ),
+)
+
+DESCHEDULE = CommandInfo(
+    command="deschedule",
+    brief="/deschedule - Remove the weekly schedule",
+    usage="/deschedule",
+)
+
+AUTHORIZE = CommandInfo(
+    command="authorize",
+    brief="/authorize - Authorize this chat to use ONGAbot (bot admins only)",
+    usage="/authorize",
+)
+
+DEAUTHORIZE = CommandInfo(
+    command="deauthorize",
+    brief="/deauthorize - Deauthorize this chat from using ONGAbot (bot admins only)",
+    usage="/deauthorize",
+)
+
+# Ordered for help text assembly
+ALL_COMMANDS = [
+    HELP,
+    ONGA,
+    NEWEVENT,
+    CANCELEVENT,
+    UPDATEEVENT,
+    SCHEDULE,
+    RESCHEDULE,
+    DESCHEDULE,
+    AUTHORIZE,
+    DEAUTHORIZE,
+]

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -1,11 +1,13 @@
 """This module contains helper functions."""
 
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta
+
+from .commands import ALL_COMMANDS
 
 
 def create_help_text() -> str:
     """Print the help text for a /start or /help command"""
-    text = (
+    header = (
         "Welcome traveler, my name is ONGAbot.\n"
         "I'm the one and only, the truth speaker.\n"
         "\n"
@@ -16,19 +18,8 @@ def create_help_text() -> str:
         " - Condemn the wicked\n"
         "\n"
         "Commandments:\n"
-        "/help - Get some aid in needing times\n"
-        "/onga - This is the way, let me show you\n"
-        "/newevent - Create a new event corresponding to upcoming Wednesday and pins it\n"
-        "/cancelevent - Cancels the latest default event, i.e. unpins it\n"
-        "/schedule <day>[OPTIONAL] - Schedules a job to create a poll on "
-        "every upcoming <day>. If no argument is supplied, job"
-        " is scheduled to run on sundays\n"
-        "/deschedule - Deschedules jobs\n"
-        "/authorize - Authorize this chat to use ONGAbot (bot admins only)\n"
-        "/deauthorize - Deauthorize this chat from using ONGAbot (bot admins only)"
     )
-
-    return text
+    return header + "\n".join(cmd.brief for cmd in ALL_COMMANDS)
 
 
 def get_upcoming_date(today: date, upcoming_weekday: str) -> date:
@@ -65,3 +56,88 @@ def get_weekday_index_from_name(day_name: str) -> int:
         "saturday": 5,
         "sunday": 6,
     }[day_name.lower()]
+
+
+def parse_date(token: str) -> date:
+    """
+    Parse a day-or-date token into a concrete date.
+
+    Accepts weekday names ("wednesday"), ISO dates ("2026-05-10"), or dd.mm.yyyy dates.
+    Returns the next upcoming occurrence for weekday names.
+    Raises ValueError if the token cannot be parsed.
+    """
+    if is_valid_weekday(token):
+        return get_upcoming_date(date.today(), token.lower())
+    for fmt in ("%Y-%m-%d", "%d.%m.%Y"):
+        try:
+            return datetime.strptime(token, fmt).date()
+        except ValueError:
+            continue
+    raise ValueError(f"Cannot parse date from: {token!r}. Use a weekday name, YYYY-MM-DD, or dd.mm.yyyy.")
+
+
+def parse_time(token: str) -> time:
+    """
+    Parse a HH:MM string into a datetime.time.
+    Raises ValueError if the format is wrong.
+    """
+    try:
+        return datetime.strptime(token, "%H:%M").time()
+    except ValueError as e:
+        raise ValueError(f"Cannot parse time from: {token!r}. Use HH:MM format (e.g. 18:30).") from e
+
+
+def parse_num_slots(value: str) -> int:
+    """Parse and validate a number-of-slots value. Raises ValueError if not a positive integer."""
+    try:
+        num = int(value)
+    except ValueError as e:
+        raise ValueError(f"slots must be a positive integer, got: {value!r}") from e
+    if num < 1:
+        raise ValueError(f"slots must be a positive integer, got: {value!r}")
+    return num
+
+
+def parse_event_job_args(
+    args: list[str],
+    trigger_on: str,
+    event_day: str,
+    start_time: time,
+    num_slots: int,
+) -> tuple[str, str, time, int]:
+    """Parse trigger_on/day/time/slots args for schedule/reschedule commands, using supplied values as defaults.
+
+    Raises ValueError on invalid input.
+    """
+    named = parse_named_args(args, {"trigger_on", "day", "time", "slots"})
+    if "trigger_on" in named:
+        if not is_valid_weekday(named["trigger_on"]):
+            raise ValueError(f"Invalid weekday: {named['trigger_on']!r}")
+        trigger_on = named["trigger_on"].lower()
+    if "day" in named:
+        if not is_valid_weekday(named["day"]):
+            raise ValueError(f"Invalid weekday: {named['day']!r}")
+        event_day = named["day"].lower()
+    if "time" in named:
+        start_time = parse_time(named["time"])
+    if "slots" in named:
+        num_slots = parse_num_slots(named["slots"])
+    return trigger_on, event_day, start_time, num_slots
+
+
+def parse_named_args(args: list[str], allowed_keys: set[str]) -> dict[str, str]:
+    """
+    Parse a list of key=value argument strings, validating keys against an allowed set.
+
+    Raises ValueError if any arg is not key=value, or if a key is not in allowed_keys.
+    """
+    result: dict[str, str] = {}
+    for arg in args:
+        if "=" not in arg:
+            raise ValueError(f"Expected key=value format, got: {arg!r}")
+        key, _, value = arg.partition("=")
+        if key.lower() not in allowed_keys:
+            known = ", ".join(sorted(allowed_keys))
+            raise ValueError(f"Unknown argument key: {key!r}. Known keys: {known}")
+        result[key.lower()] = value
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,14 @@
 [tool.black]
-line-length = 100
+line-length = 120
+
+[tool.pylint.design]
+max-args = 10
+max-attributes = 10
+max-positional-arguments=10
+
+[tool.pylint.format]
+max-line-length = 120
 
 [tool.pylint.'SIMILARITIES']
-min-similarity-lines=5
+min-similarity-lines=10
 ignore-imports=true

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 100
+max-line-length = 120
 
 [mypy]
 warn_unused_ignores = True

--- a/tests/test_eventdata.py
+++ b/tests/test_eventdata.py
@@ -1,0 +1,33 @@
+from ongabot.eventdata import DEFAULT_EVENT_DAY, DEFAULT_NUM_SLOTS, DEFAULT_START_TIME, EventData
+
+from datetime import date, time
+import unittest
+
+
+class EventDataDefaultsTest(unittest.TestCase):
+    def test_default_start_time(self):
+        self.assertEqual(EventData().start_time, DEFAULT_START_TIME)
+
+    def test_default_num_slots(self):
+        self.assertEqual(EventData().num_slots, DEFAULT_NUM_SLOTS)
+
+    def test_default_event_date_is_upcoming_default_day(self):
+        weekday_index = {
+            "monday": 0,
+            "tuesday": 1,
+            "wednesday": 2,
+            "thursday": 3,
+            "friday": 4,
+            "saturday": 5,
+            "sunday": 6,
+        }[DEFAULT_EVENT_DAY]
+        self.assertEqual(EventData().event_date.weekday(), weekday_index)
+
+    def test_explicit_values(self):
+        d, t, n = date(2026, 5, 7), time(20, 0), 3
+        e = EventData(d, t, n)
+        self.assertEqual((e.event_date, e.start_time, e.num_slots), (d, t, n))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_eventjob.py
+++ b/tests/test_eventjob.py
@@ -1,0 +1,80 @@
+from ongabot.eventjob import DEFAULT_TRIGGER_DAY, EventJob
+from ongabot.eventdata import DEFAULT_EVENT_DAY, DEFAULT_NUM_SLOTS, DEFAULT_START_TIME
+
+from datetime import time
+import unittest
+
+
+class EventJobToEventDataTest(unittest.TestCase):
+    def setUp(self):
+        self.job = EventJob(chat_id=1, event_day="wednesday", start_time=time(18, 30), num_slots=5)
+
+    def test_to_event_data_weekday(self):
+        self.assertEqual(self.job.to_event_data().event_date.weekday(), 2)
+
+    def test_to_event_data_start_time(self):
+        self.assertEqual(self.job.to_event_data().start_time, time(18, 30))
+
+    def test_to_event_data_num_slots(self):
+        self.assertEqual(self.job.to_event_data().num_slots, 5)
+
+    def test_to_event_data_reflects_job_attrs(self):
+        job = EventJob(chat_id=1, event_day="friday", start_time=time(20, 0), num_slots=3)
+        result = job.to_event_data()
+        self.assertEqual(result.event_date.weekday(), 4)
+        self.assertEqual(result.start_time, time(20, 0))
+        self.assertEqual(result.num_slots, 3)
+
+
+class EventJobSetStateTest(unittest.TestCase):
+    def _make(self, state: dict) -> EventJob:
+        obj = EventJob.__new__(EventJob)
+        obj.__setstate__(state)
+        return obj
+
+    def test_migrates_day_to_schedule_to_trigger_on(self):
+        obj = self._make({"chat_id": 1, "day_to_schedule": "monday", "job_name": "weeky_event_1"})
+        self.assertEqual(obj.trigger_on, "monday")
+        self.assertFalse(hasattr(obj, "day_to_schedule"))
+
+    def test_defaults_trigger_on_when_missing_entirely(self):
+        obj = self._make({"chat_id": 1, "job_name": "weeky_event_1"})
+        self.assertEqual(obj.trigger_on, DEFAULT_TRIGGER_DAY)
+
+    def test_defaults_event_day_when_missing(self):
+        obj = self._make({"chat_id": 1, "trigger_on": "sunday", "job_name": "weeky_event_1"})
+        self.assertEqual(obj.event_day, DEFAULT_EVENT_DAY)
+
+    def test_defaults_start_time_when_missing(self):
+        obj = self._make({"chat_id": 1, "trigger_on": "sunday", "event_day": "wednesday", "job_name": "weeky_event_1"})
+        self.assertEqual(obj.start_time, DEFAULT_START_TIME)
+
+    def test_defaults_num_slots_when_missing(self):
+        obj = self._make(
+            {
+                "chat_id": 1,
+                "trigger_on": "sunday",
+                "event_day": "wednesday",
+                "start_time": time(18, 30),
+                "job_name": "weeky_event_1",
+            }
+        )
+        self.assertEqual(obj.num_slots, DEFAULT_NUM_SLOTS)
+
+    def test_existing_fields_preserved(self):
+        obj = self._make(
+            {
+                "chat_id": 1,
+                "trigger_on": "friday",
+                "event_day": "saturday",
+                "start_time": time(20, 0),
+                "num_slots": 3,
+                "job_name": "weeky_event_1",
+            }
+        )
+        self.assertEqual(obj.trigger_on, "friday")
+        self.assertEqual(obj.num_slots, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,6 +1,6 @@
 from ongabot.utils import helper
 
-from datetime import date
+from datetime import date, time
 from parameterized import parameterized
 import unittest
 
@@ -26,6 +26,155 @@ class HelperTest(unittest.TestCase):
             expected,
             f"Wrong calculated date! Expected: {expected}. Actual: {result}",
         )
+
+
+class ParseDateTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("iso_date", "2026-05-07", date(2026, 5, 7)),
+            ("dd_mm_yyyy", "07.05.2026", date(2026, 5, 7)),
+        ]
+    )
+    def test_parse_date_concrete(self, _, token, expected):
+        self.assertEqual(helper.parse_date(token), expected)
+
+    @parameterized.expand(
+        [
+            ("monday", "monday", 0),
+            ("wednesday", "wednesday", 2),
+            ("sunday", "sunday", 6),
+        ]
+    )
+    def test_parse_date_weekday(self, _, token, expected_weekday):
+        self.assertEqual(helper.parse_date(token).weekday(), expected_weekday)
+
+    @parameterized.expand(
+        [
+            ("empty", ""),
+            ("slash_format", "2026/05/07"),
+            ("nonsense", "notadate"),
+            ("partial_iso", "2026-05"),
+        ]
+    )
+    def test_parse_date_raises(self, _, token):
+        with self.assertRaises(ValueError):
+            helper.parse_date(token)
+
+
+class ParseTimeTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("standard", "18:30", time(18, 30)),
+            ("midnight", "00:00", time(0, 0)),
+            ("end_of_day", "23:59", time(23, 59)),
+        ]
+    )
+    def test_parse_time_valid(self, _, token, expected):
+        self.assertEqual(helper.parse_time(token), expected)
+
+    @parameterized.expand(
+        [
+            ("dot_format", "18.30"),
+            ("hour_only", "18"),
+            ("out_of_range", "25:00"),
+            ("nonsense", "noon"),
+        ]
+    )
+    def test_parse_time_raises(self, _, token):
+        with self.assertRaises(ValueError):
+            helper.parse_time(token)
+
+
+class ParseNumSlotsTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("one", "1", 1),
+            ("five", "5", 5),
+            ("ten", "10", 10),
+        ]
+    )
+    def test_parse_num_slots_valid(self, _, value, expected):
+        self.assertEqual(helper.parse_num_slots(value), expected)
+
+    @parameterized.expand(
+        [
+            ("zero", "0"),
+            ("negative", "-1"),
+            ("float", "1.5"),
+            ("alpha", "abc"),
+            ("empty", ""),
+        ]
+    )
+    def test_parse_num_slots_raises(self, _, value):
+        with self.assertRaises(ValueError):
+            helper.parse_num_slots(value)
+
+
+class ParseNamedArgsTest(unittest.TestCase):
+    @parameterized.expand(
+        [
+            ("single", ["key=value"], {"key": "value"}),
+            ("multiple", ["a=1", "b=2"], {"a": "1", "b": "2"}),
+            ("value_with_equals", ["k=v=extra"], {"k": "v=extra"}),
+            ("key_case_folded", ["KEY=val"], {"key": "val"}),
+        ]
+    )
+    def test_parse_named_args_valid(self, _, args, expected):
+        allowed = set(expected.keys())
+        self.assertEqual(helper.parse_named_args(args, allowed), expected)
+
+    @parameterized.expand(
+        [
+            ("no_equals", ["noequalssign"]),
+            ("unknown_key", ["foo=bar"]),
+            ("empty_key", ["=value"]),
+        ]
+    )
+    def test_parse_named_args_raises(self, _, args):
+        with self.assertRaises(ValueError):
+            helper.parse_named_args(args, {"known"})
+
+
+class ParseEventJobArgsTest(unittest.TestCase):
+    DEFAULTS = ("sunday", "wednesday", time(18, 30), 5)
+
+    def test_no_args_returns_defaults(self):
+        self.assertEqual(helper.parse_event_job_args([], *self.DEFAULTS), self.DEFAULTS)
+
+    def test_override_trigger_on(self):
+        result = helper.parse_event_job_args(["trigger_on=monday"], *self.DEFAULTS)
+        self.assertEqual(result[0], "monday")
+
+    def test_override_day(self):
+        result = helper.parse_event_job_args(["day=thursday"], *self.DEFAULTS)
+        self.assertEqual(result[1], "thursday")
+
+    def test_override_time(self):
+        result = helper.parse_event_job_args(["time=20:00"], *self.DEFAULTS)
+        self.assertEqual(result[2], time(20, 0))
+
+    def test_override_slots(self):
+        result = helper.parse_event_job_args(["slots=3"], *self.DEFAULTS)
+        self.assertEqual(result[3], 3)
+
+    def test_override_all(self):
+        args = ["trigger_on=monday", "day=thursday", "time=19:00", "slots=3"]
+        self.assertEqual(
+            helper.parse_event_job_args(args, *self.DEFAULTS),
+            ("monday", "thursday", time(19, 0), 3),
+        )
+
+    @parameterized.expand(
+        [
+            ("invalid_trigger_on", ["trigger_on=notaday"]),
+            ("invalid_day", ["day=notaday"]),
+            ("invalid_time", ["time=99:99"]),
+            ("invalid_slots", ["slots=0"]),
+        ]
+    )
+    def test_invalid_args_raise(self, _, args):
+        with self.assertRaises(ValueError):
+            helper.parse_event_job_args(args, *self.DEFAULTS)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- Add day=, time=, slots= args to /newevent, /schedule, /reschedule
- Add /updateevent to reconfigure an active event (day/time/slots)
- Add /cancelevent target_date= filter accepting weekday or date
- Extract EventData dataclass grouping event_date/start_time/num_slots
- Refactor EventJob: add to_event_data(), remove check_if_job_exists()
- Centralize command metadata in utils/commands.py (brief + usage strings)
- Add authorization system (/authorize, /deauthorize, bot admin check)
- Fix missing await on event.update_status_message() in poll handler
- Extend test suite: parse_date/time/slots/named_args, EventData, EventJob