### PR TITLE
fix: make @log and @log.method decorators async-aware

### DIFF
--- a/ongabot/utils/log.py
+++ b/ongabot/utils/log.py
@@ -1,6 +1,7 @@
 """This module contains log decorator."""
 
 import functools
+import inspect
 import logging
 from typing import Any, Callable, TypeVar, cast
 
@@ -9,9 +10,21 @@ F = TypeVar("F", bound=Callable[..., Any])  # pylint: disable=invalid-name
 
 def log(func: F) -> F:
     """Log decorator to give ENTER/EXIT logs of a function"""
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_decorator(*args: object, **kwargs: object) -> Any:
+            logger = logging.getLogger(func.__module__)
+            logger.debug("ENTER: %s", func.__name__)
+            result = await func(*args, **kwargs)
+            logger.debug("RESULT: %s", result)
+            logger.debug("EXIT: %s", func.__name__)
+            return result
+
+        return cast(F, async_decorator)
 
     @functools.wraps(func)
-    def decorator(*args: object, **kwargs: object) -> Any:
+    def sync_decorator(*args: object, **kwargs: object) -> Any:
         logger = logging.getLogger(func.__module__)
         logger.debug("ENTER: %s", func.__name__)
         result = func(*args, **kwargs)
@@ -19,14 +32,26 @@ def log(func: F) -> F:
         logger.debug("EXIT: %s", func.__name__)
         return result
 
-    return cast(F, decorator)
+    return cast(F, sync_decorator)
 
 
 def method(func: F) -> F:
     """Log decorator to give ENTER/EXIT logs of a class method"""
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_decorator(self: object, *args: object, **kwargs: object) -> Any:
+            logger = logging.getLogger(func.__module__)
+            logger.debug("ENTER: %s", func.__name__)
+            result = await func(self, *args, **kwargs)
+            logger.debug("RESULT: %s", result)
+            logger.debug("EXIT: %s", func.__name__)
+            return result
+
+        return cast(F, async_decorator)
 
     @functools.wraps(func)
-    def decorator(self: object, *args: object, **kwargs: object) -> Any:
+    def sync_decorator(self: object, *args: object, **kwargs: object) -> Any:
         logger = logging.getLogger(func.__module__)
         logger.debug("ENTER: %s", func.__name__)
         result = func(self, *args, **kwargs)
@@ -34,4 +59,4 @@ def method(func: F) -> F:
         logger.debug("EXIT: %s", func.__name__)
         return result
 
-    return cast(F, decorator)
+    return cast(F, sync_decorator)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,0 +1,120 @@
+import inspect
+import unittest
+
+from ongabot.utils import log
+
+
+class LogSyncTest(unittest.TestCase):
+    def test_sync_function_returns_result(self):
+        @log.log
+        def add(a, b):
+            return a + b
+
+        self.assertEqual(add(1, 2), 3)
+
+    def test_sync_function_preserves_name(self):
+        @log.log
+        def my_func():
+            pass
+
+        self.assertEqual(my_func.__name__, "my_func")
+
+    def test_sync_decorated_is_not_coroutine_function(self):
+        @log.log
+        def my_func():
+            return 1
+
+        self.assertFalse(inspect.iscoroutinefunction(my_func))
+
+
+class LogMethodSyncTest(unittest.TestCase):
+    def test_sync_method_returns_result(self):
+        class MyClass:
+            @log.method
+            def add(self, a, b):
+                return a + b
+
+        self.assertEqual(MyClass().add(1, 2), 3)
+
+    def test_sync_method_preserves_name(self):
+        class MyClass:
+            @log.method
+            def my_method(self):
+                pass
+
+        self.assertEqual(MyClass.my_method.__name__, "my_method")
+
+    def test_sync_method_decorated_is_not_coroutine_function(self):
+        class MyClass:
+            @log.method
+            def my_method(self):
+                return 1
+
+        self.assertFalse(inspect.iscoroutinefunction(MyClass.my_method))
+
+
+class LogAsyncTest(unittest.TestCase):
+    def test_async_decorated_is_coroutine_function(self):
+        @log.log
+        async def my_func():
+            return 42
+
+        self.assertTrue(inspect.iscoroutinefunction(my_func))
+
+    def test_async_function_preserves_name(self):
+        @log.log
+        async def my_func():
+            pass
+
+        self.assertEqual(my_func.__name__, "my_func")
+
+
+class LogAsyncExecutionTest(unittest.IsolatedAsyncioTestCase):
+    async def test_async_function_executes_body(self):
+        side_effects = []
+
+        @log.log
+        async def my_func():
+            side_effects.append("ran")
+            return 99
+
+        result = await my_func()
+        self.assertEqual(result, 99)
+        self.assertEqual(side_effects, ["ran"])
+
+
+class LogMethodAsyncTest(unittest.TestCase):
+    def test_async_method_decorated_is_coroutine_function(self):
+        class MyClass:
+            @log.method
+            async def my_method(self):
+                return 42
+
+        self.assertTrue(inspect.iscoroutinefunction(MyClass.my_method))
+
+    def test_async_method_preserves_name(self):
+        class MyClass:
+            @log.method
+            async def my_method(self):
+                pass
+
+        self.assertEqual(MyClass.my_method.__name__, "my_method")
+
+
+class LogMethodAsyncExecutionTest(unittest.IsolatedAsyncioTestCase):
+    async def test_async_method_executes_body(self):
+        side_effects = []
+
+        class MyClass:
+            @log.method
+            async def my_method(self):
+                side_effects.append("ran")
+                return 99
+
+        result = await MyClass().my_method()
+        self.assertEqual(result, 99)
+        self.assertEqual(side_effects, ["ran"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Both `@log` and `@log.method` decorators were sync-only wrappers that silently broke async functions: `func(*args, **kwargs)` returned a coroutine object without executing the body, causing `RESULT: <coroutine object ...>` in logs and `inspect.iscoroutinefunction(decorated)` returning `False`
- Fixed by branching on `inspect.iscoroutinefunction(func)` at decoration time, returning an `async def` wrapper for async functions that properly `await`s the call
- Added `tests/test_log.py` with 12 tests covering sync and async behavior of both decorators

## Test Plan
- [x] `make test` — 71 tests pass
- [x] `make check` — black, pylint, flake8, mypy all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)