### PR TITLE
fix: guard against None event in poll handler callbacks (I2)

### DIFF
--- a/ongabot/handler/eventpollanswerhandler.py
+++ b/ongabot/handler/eventpollanswerhandler.py
@@ -27,6 +27,7 @@ async def callback(update: Update, context: CallbackContext) -> None:
 
     event = context.bot_data.get_event(update.poll_answer.poll_id)
     if event is None:
+        _logger.error("Received poll answer update for unknown poll_id=%s", update.poll_answer.poll_id)
         return
     event.update_answer(update.poll_answer)
     await event.update_status_message(context.bot)

--- a/ongabot/handler/eventpollanswerhandler.py
+++ b/ongabot/handler/eventpollanswerhandler.py
@@ -26,6 +26,8 @@ async def callback(update: Update, context: CallbackContext) -> None:
         return
 
     event = context.bot_data.get_event(update.poll_answer.poll_id)
+    if event is None:
+        return
     event.update_answer(update.poll_answer)
     await event.update_status_message(context.bot)
 

--- a/ongabot/handler/eventpollhandler.py
+++ b/ongabot/handler/eventpollhandler.py
@@ -26,6 +26,7 @@ async def callback(update: Update, context: CallbackContext) -> None:
 
     event = context.bot_data.get_event(update.poll.id)
     if event is None:
+        _logger.error("Received poll update for unknown poll_id=%s", update.poll.id)
         return
     event.update_poll(update.poll)
     await event.update_status_message(context.bot)

--- a/ongabot/handler/eventpollhandler.py
+++ b/ongabot/handler/eventpollhandler.py
@@ -25,5 +25,7 @@ async def callback(update: Update, context: CallbackContext) -> None:
         return
 
     event = context.bot_data.get_event(update.poll.id)
+    if event is None:
+        return
     event.update_poll(update.poll)
     await event.update_status_message(context.bot)

--- a/tests/test_eventpollanswerhandler.py
+++ b/tests/test_eventpollanswerhandler.py
@@ -1,0 +1,22 @@
+import unittest
+from unittest.mock import MagicMock
+
+from ongabot.handler.eventpollanswerhandler import callback
+
+
+class EventPollAnswerCallbackNoneEventTest(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_early_when_event_is_none(self):
+        update = MagicMock()
+        update.poll_answer.poll_id = "unknown_poll_id"
+        update.poll_answer.user = MagicMock()
+        context = MagicMock()
+        context.bot_data.get_event.return_value = None
+
+        await callback(update, context)
+
+        context.bot_data.get_event.assert_called_once_with("unknown_poll_id")
+        context.bot.send_message.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_eventpollhandler.py
+++ b/tests/test_eventpollhandler.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import MagicMock
+
+from ongabot.handler.eventpollhandler import callback
+
+
+class EventPollCallbackNoneEventTest(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_early_when_event_is_none(self):
+        update = MagicMock()
+        update.poll.id = "unknown_poll_id"
+        context = MagicMock()
+        context.bot_data.get_event.return_value = None
+
+        await callback(update, context)
+
+        context.bot_data.get_event.assert_called_once_with("unknown_poll_id")
+        update.poll.id  # confirms poll was accessed before the guard, not silently skipped

--- a/tests/test_eventpollhandler.py
+++ b/tests/test_eventpollhandler.py
@@ -14,4 +14,8 @@ class EventPollCallbackNoneEventTest(unittest.IsolatedAsyncioTestCase):
         await callback(update, context)
 
         context.bot_data.get_event.assert_called_once_with("unknown_poll_id")
-        update.poll.id  # confirms poll was accessed before the guard, not silently skipped
+        context.bot.send_message.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `if event is None: return` guard in `EventPollHandler` and `EventPollAnswerHandler` callbacks — `BotData.get_event()` returns `None` when a poll ID is unrecognised (e.g. bot restarted with empty DB, or a poll not created by this bot), and both callbacks previously called methods on the result unconditionally, causing `AttributeError`
- Add tests covering the early-return path in both handlers

## Test Plan

- [x] `make test` — 73 tests pass, including `EventPollCallbackNoneEventTest` and `EventPollAnswerCallbackNoneEventTest`
- [x] `make check` — pylint 10.00/10, mypy clean, flake8 clean, black unchanged