### PR TITLE
ci: add coverage enforcement and pip cache

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.14"
+          cache: 'pip'
 
       - name: Install dependencies
         run: |

--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ black:
 	$(BLACK) .
 
 test:
-	$(PYTEST) -v
+	$(PYTEST) -v --cov=ongabot --cov-report=term-missing --cov-fail-under=46
 
 clean:
 	rm -rf $(VENV_PATH)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,4 +3,5 @@ flake8==7.3.0
 mypy==1.20.2
 pylint==4.0.5
 pytest==9.0.3
+pytest-cov==7.1.0
 parameterized==0.9.0


### PR DESCRIPTION
## Summary

- Add `pytest-cov==7.1.0` to `requirements-dev.txt` and update `make test` to run with `--cov=ongabot --cov-report=term-missing --cov-fail-under=46` (I11)
- Add `cache: 'pip'` to `actions/setup-python` in the GitHub Actions workflow to skip redundant pip downloads (I12)

## Test Plan

- [x] `make test` passes with coverage report and "Required test coverage of 46% reached"
- [x] `make check` passes (black, pylint, flake8, mypy)
- [x] CI run shows pip cache hit on second run