### PR TITLE
fix: surgical TelegramError handling and startup guard (I7/I8)

### DIFF
--- a/docs/superpowers/specs/2026-05-13-error-handling-i7-i8-design.md
+++ b/docs/superpowers/specs/2026-05-13-error-handling-i7-i8-design.md
@@ -1,0 +1,68 @@
+# Error Handling: I7 & I8
+
+**Date:** 2026-05-13
+
+## Overview
+
+Two targeted hardening improvements:
+
+- **I7** — Wrap Telegram API calls in job callbacks and multi-step event creation so failures are logged and non-fatal.
+- **I8** — Wrap `schedule_all_event_jobs` in `post_init` so a corrupt pickle doesn't crash startup.
+
+## Scope
+
+**In scope:**
+- Job callbacks: `create_event_callback`, `complete_past_events_callback`
+- Multi-step create flow: `eventcreator.py:create_event`
+- Startup scheduling: `ongabot.py:post_init`
+
+**Out of scope:**
+- Command handler `reply_text`/`send_message` calls — the global error handler already logs these.
+- Rollback/cleanup of partial state (e.g. deleting a poll that was sent when the subsequent pin fails).
+
+## I7 — Surgical TelegramError Handling
+
+### `eventcreator.py:create_event`
+
+Three sequential API calls; only `send_poll` is fatal. Status-message and pin failures are non-fatal — the event is still tracked.
+
+```
+send_poll       → fatal: log error and return (no event object to register)
+send_status_message → non-fatal: log error, continue (event has no status message)
+pin             → non-fatal: log error, continue (event is registered, just unpinned)
+```
+
+Each step wrapped individually with `except TelegramError`.
+
+### `ongabot.py:complete_past_events_callback`
+
+Per-event try/except around `update_status_message` so one chat's API failure doesn't abort processing for all other chats. `remove_pinned_poll` already has its own try/except in `chat.py`.
+
+### Import
+
+`from telegram.error import TelegramError` added to `eventcreator.py` and `ongabot.py`.
+
+## I8 — Startup Bot Data Validation
+
+### `ongabot.py:post_init`
+
+Wrap `bot_data.schedule_all_event_jobs(...)` in `try/except Exception`. On failure:
+- Log a clear `ERROR` message indicating recurring polls will not fire.
+- Continue — bot starts normally, operator is alerted via logs.
+
+No data is discarded. The `BotData.__setstate__`, `Chat.__setstate__`, and `Event.__setstate__` methods already defend against missing attributes from older pickles. This guard covers the residual case where deserialization succeeds but scheduling itself raises.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `ongabot/eventcreator.py` | Add `TelegramError` import; wrap `send_poll`, `send_status_message`, `pin` individually |
+| `ongabot/ongabot.py` | Add `TelegramError` import; per-event wrap in `complete_past_events_callback`; try/except around `schedule_all_event_jobs` in `post_init` |
+
+## Testing
+
+- Unit test: `create_event` where `send_poll` raises `TelegramError` → function returns early, no event added to chat.
+- Unit test: `create_event` where `send_status_message` raises → event still added to chat.
+- Unit test: `create_event` where `pin` raises → event still added and pinned-poll not registered.
+- Unit test: `complete_past_events_callback` where `update_status_message` raises for one event → other events still processed.
+- Unit test: `post_init` where `schedule_all_event_jobs` raises → no exception propagates, error is logged.

--- a/ongabot/eventcreator.py
+++ b/ongabot/eventcreator.py
@@ -69,7 +69,7 @@ async def create_event(
     try:
         await event.send_status_message(context.bot)
     except TelegramError as exc:
-        _logger.error("Failed to send status message for poll_id=%s: %s", event.poll_id, exc)
+        _logger.error("Failed to send status message for chat_id=%s poll_id=%s: %s", chat_id, event.poll_id, exc)
 
     chat.add_event(event)
 
@@ -78,7 +78,7 @@ async def create_event(
         await poll_message.pin(disable_notification=True)
         chat.set_pinned_poll(poll_message.poll.id, poll_message)
     except TelegramError as exc:
-        _logger.error("Failed to pin poll message for poll_id=%s: %s", event.poll_id, exc)
+        _logger.error("Failed to pin poll message for chat_id=%s poll_id=%s: %s", chat_id, event.poll_id, exc)
 
 
 _EVENT_NAME_BY_WEEKDAY = {

--- a/ongabot/eventcreator.py
+++ b/ongabot/eventcreator.py
@@ -58,8 +58,8 @@ async def create_event(
             is_anonymous=False,
             allows_multiple_answers=True,
         )
-    except TelegramError as exc:
-        _logger.error("Failed to send poll for chat_id=%s: %s", chat_id, exc)
+    except TelegramError as e:
+        _logger.error("Failed to send poll for chat_id=%s: %s", chat_id, e)
         return
 
     _logger.debug("poll_message:\n%s", poll_message)
@@ -68,8 +68,8 @@ async def create_event(
 
     try:
         await event.send_status_message(context.bot)
-    except TelegramError as exc:
-        _logger.error("Failed to send status message for chat_id=%s poll_id=%s: %s", chat_id, event.poll_id, exc)
+    except TelegramError as e:
+        _logger.error("Failed to send status message for chat_id=%s poll_id=%s: %s", chat_id, event.poll_id, e)
 
     chat.add_event(event)
 
@@ -77,8 +77,8 @@ async def create_event(
     try:
         await poll_message.pin(disable_notification=True)
         chat.set_pinned_poll(poll_message.poll.id, poll_message)
-    except TelegramError as exc:
-        _logger.error("Failed to pin poll message for chat_id=%s poll_id=%s: %s", chat_id, event.poll_id, exc)
+    except TelegramError as e:
+        _logger.error("Failed to pin poll message for chat_id=%s poll_id=%s: %s", chat_id, event.poll_id, e)
 
 
 _EVENT_NAME_BY_WEEKDAY = {

--- a/ongabot/eventcreator.py
+++ b/ongabot/eventcreator.py
@@ -3,6 +3,7 @@
 import logging
 from datetime import date, datetime, time, timedelta
 
+from telegram.error import TelegramError
 from telegram.ext import CallbackContext
 
 from chat import Chat
@@ -49,23 +50,35 @@ async def create_event(
             _logger.debug("Event already exists for date %s.", event_data.event_date)
             return
 
-    poll_message = await context.bot.send_poll(
-        chat_id,
-        _create_poll_text(event_data.event_date, event_data.start_time),
-        options=_create_poll_options(event_data.start_time, event_data.num_slots),
-        is_anonymous=False,
-        allows_multiple_answers=True,
-    )
+    try:
+        poll_message = await context.bot.send_poll(
+            chat_id,
+            _create_poll_text(event_data.event_date, event_data.start_time),
+            options=_create_poll_options(event_data.start_time, event_data.num_slots),
+            is_anonymous=False,
+            allows_multiple_answers=True,
+        )
+    except TelegramError as exc:
+        _logger.error("Failed to send poll for chat_id=%s: %s", chat_id, exc)
+        return
+
     _logger.debug("poll_message:\n%s", poll_message)
 
     event = Event(chat_id, poll_message.poll, event_data)
-    await event.send_status_message(context.bot)
+
+    try:
+        await event.send_status_message(context.bot)
+    except TelegramError as exc:
+        _logger.error("Failed to send status message for poll_id=%s: %s", event.poll_id, exc)
 
     chat.add_event(event)
 
     # Pin new message and save to chat data for future removal
-    await poll_message.pin(disable_notification=True)
-    chat.set_pinned_poll(poll_message.poll.id, poll_message)
+    try:
+        await poll_message.pin(disable_notification=True)
+        chat.set_pinned_poll(poll_message.poll.id, poll_message)
+    except TelegramError as exc:
+        _logger.error("Failed to pin poll message for poll_id=%s: %s", event.poll_id, exc)
 
 
 _EVENT_NAME_BY_WEEKDAY = {

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -6,6 +6,7 @@ import logging
 import os
 
 from telegram.ext import Application, CallbackContext, ContextTypes, PicklePersistence
+from telegram.error import TelegramError
 
 import eventcreator
 from botdata import BotData
@@ -44,7 +45,14 @@ async def complete_past_events_callback(context: CallbackContext) -> None:
         for event in list(chat.events.values()):
             if not event.completed and event.event_date < today:
                 event.mark_complete()
-                await event.update_status_message(context.bot)
+                try:
+                    await event.update_status_message(context.bot)
+                except TelegramError as exc:
+                    logger.error(
+                        "Failed to update status message for poll_id=%s: %s",
+                        event.poll_id,
+                        exc,
+                    )
                 await chat.remove_pinned_poll(event.poll_id)
                 logger.info(
                     "Auto-completed past event poll_id=%s (date=%s) in chat_id=%s",

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -84,7 +84,13 @@ async def post_init(application: Application) -> None:
         logger.error("Job queue is not available in post_init. Event cleanup jobs will not be scheduled.")
         return
 
-    bot_data.schedule_all_event_jobs(application.job_queue, eventcreator.create_event_callback)
+    try:
+        bot_data.schedule_all_event_jobs(application.job_queue, eventcreator.create_event_callback)
+    except Exception as exc:  # pylint: disable=broad-except
+        logger.error(
+            "Failed to restore event jobs from persisted data — recurring polls will not fire: %s",
+            exc,
+        )
 
     # Schedule daily cleanup of past events
     application.job_queue.run_once(complete_past_events_callback, when=5, name="complete_past_events_startup")

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -47,21 +47,21 @@ async def complete_past_events_callback(context: CallbackContext) -> None:
                 event.mark_complete()
                 try:
                     await event.update_status_message(context.bot)
-                except TelegramError as exc:
+                except TelegramError as e:
                     logger.error(
                         "Failed to update status message for chat_id=%s poll_id=%s: %s",
                         chat.chat_id,
                         event.poll_id,
-                        exc,
+                        e,
                     )
                 try:
                     await chat.remove_pinned_poll(event.poll_id)
-                except TelegramError as exc:
+                except TelegramError as e:
                     logger.error(
                         "Failed to remove pinned poll for chat_id=%s poll_id=%s: %s",
                         chat.chat_id,
                         event.poll_id,
-                        exc,
+                        e,
                     )
                 logger.info(
                     "Auto-completed past event poll_id=%s (date=%s) in chat_id=%s",
@@ -86,10 +86,10 @@ async def post_init(application: Application) -> None:
 
     try:
         bot_data.schedule_all_event_jobs(application.job_queue, eventcreator.create_event_callback)
-    except Exception as exc:  # pylint: disable=broad-except
+    except Exception as e:  # pylint: disable=broad-except
         logger.error(
             "Failed to restore event jobs from persisted data — recurring polls will not fire: %s",
-            exc,
+            e,
         )
 
     # Schedule daily cleanup of past events

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -49,11 +49,20 @@ async def complete_past_events_callback(context: CallbackContext) -> None:
                     await event.update_status_message(context.bot)
                 except TelegramError as exc:
                     logger.error(
-                        "Failed to update status message for poll_id=%s: %s",
+                        "Failed to update status message for chat_id=%s poll_id=%s: %s",
+                        chat.chat_id,
                         event.poll_id,
                         exc,
                     )
-                await chat.remove_pinned_poll(event.poll_id)
+                try:
+                    await chat.remove_pinned_poll(event.poll_id)
+                except TelegramError as exc:
+                    logger.error(
+                        "Failed to remove pinned poll for chat_id=%s poll_id=%s: %s",
+                        chat.chat_id,
+                        event.poll_id,
+                        exc,
+                    )
                 logger.info(
                     "Auto-completed past event poll_id=%s (date=%s) in chat_id=%s",
                     event.poll_id,

--- a/tests/test_eventcreator.py
+++ b/tests/test_eventcreator.py
@@ -1,0 +1,69 @@
+import unittest
+from datetime import date, time
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from telegram.error import TelegramError
+
+from ongabot import eventcreator
+from ongabot.eventdata import EventData
+
+
+class CreateEventSendPollFailsTest(unittest.IsolatedAsyncioTestCase):
+    async def test_returns_early_when_send_poll_raises(self):
+        context = MagicMock()
+        context.bot.send_poll = AsyncMock(side_effect=TelegramError("network error"))
+        chat = MagicMock()
+        chat.active_events = []
+        context.bot_data.get_chat.return_value = chat
+        event_data = EventData(date(2026, 6, 3), time(18, 30), 5)
+
+        await eventcreator.create_event(context, 123, event_data)
+
+        chat.add_event.assert_not_called()
+
+
+class CreateEventSendStatusFailsTest(unittest.IsolatedAsyncioTestCase):
+    async def test_event_still_added_when_send_status_message_raises(self):
+        poll_message = MagicMock()
+        poll_message.pin = AsyncMock()
+        context = MagicMock()
+        context.bot.send_poll = AsyncMock(return_value=poll_message)
+        chat = MagicMock()
+        chat.active_events = []
+        context.bot_data.get_chat.return_value = chat
+        event_data = EventData(date(2026, 6, 3), time(18, 30), 5)
+
+        with patch("ongabot.eventcreator.Event") as MockEvent:
+            mock_event = MagicMock()
+            mock_event.send_status_message = AsyncMock(side_effect=TelegramError("forbidden"))
+            MockEvent.return_value = mock_event
+
+            await eventcreator.create_event(context, 123, event_data)
+
+        chat.add_event.assert_called_once_with(mock_event)
+
+
+class CreateEventPinFailsTest(unittest.IsolatedAsyncioTestCase):
+    async def test_event_added_but_not_pinned_when_pin_raises(self):
+        poll_message = MagicMock()
+        poll_message.pin = AsyncMock(side_effect=TelegramError("forbidden"))
+        context = MagicMock()
+        context.bot.send_poll = AsyncMock(return_value=poll_message)
+        chat = MagicMock()
+        chat.active_events = []
+        context.bot_data.get_chat.return_value = chat
+        event_data = EventData(date(2026, 6, 3), time(18, 30), 5)
+
+        with patch("ongabot.eventcreator.Event") as MockEvent:
+            mock_event = MagicMock()
+            mock_event.send_status_message = AsyncMock()
+            MockEvent.return_value = mock_event
+
+            await eventcreator.create_event(context, 123, event_data)
+
+        chat.add_event.assert_called_once_with(mock_event)
+        chat.set_pinned_poll.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_eventcreator.py
+++ b/tests/test_eventcreator.py
@@ -19,6 +19,7 @@ class CreateEventSendPollFailsTest(unittest.IsolatedAsyncioTestCase):
 
         await eventcreator.create_event(context, 123, event_data)
 
+        context.bot.send_poll.assert_called_once()
         chat.add_event.assert_not_called()
 
 
@@ -63,6 +64,29 @@ class CreateEventPinFailsTest(unittest.IsolatedAsyncioTestCase):
 
         chat.add_event.assert_called_once_with(mock_event)
         chat.set_pinned_poll.assert_not_called()
+
+
+class CreateEventHappyPathTest(unittest.IsolatedAsyncioTestCase):
+    async def test_event_added_and_pinned_on_success(self):
+        poll_message = MagicMock()
+        poll_message.pin = AsyncMock()
+        context = MagicMock()
+        context.bot.send_poll = AsyncMock(return_value=poll_message)
+        chat = MagicMock()
+        chat.active_events = []
+        context.bot_data.get_chat.return_value = chat
+        event_data = EventData(date(2026, 6, 3), time(18, 30), 5)
+
+        with patch("ongabot.eventcreator.Event") as MockEvent:
+            mock_event = MagicMock()
+            mock_event.send_status_message = AsyncMock()
+            MockEvent.return_value = mock_event
+
+            await eventcreator.create_event(context, 123, event_data)
+
+        chat.add_event.assert_called_once_with(mock_event)
+        poll_message.pin.assert_called_once_with(disable_notification=True)
+        chat.set_pinned_poll.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -1,0 +1,38 @@
+import unittest
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock
+
+from telegram.error import TelegramError
+
+from ongabot import ongabot
+
+
+class CompletePastEventsCallbackTest(unittest.IsolatedAsyncioTestCase):
+    async def test_second_event_processed_when_first_update_status_raises(self):
+        event1 = MagicMock()
+        event1.completed = False
+        event1.event_date = date(2020, 1, 1)
+        event1.poll_id = "poll1"
+        event1.update_status_message = AsyncMock(side_effect=TelegramError("timeout"))
+
+        event2 = MagicMock()
+        event2.completed = False
+        event2.event_date = date(2020, 1, 2)
+        event2.poll_id = "poll2"
+        event2.update_status_message = AsyncMock()
+
+        chat = MagicMock()
+        chat.events = {"poll1": event1, "poll2": event2}
+        chat.remove_pinned_poll = AsyncMock()
+
+        context = MagicMock()
+        context.bot_data.chats = {"chat1": chat}
+
+        await ongabot.complete_past_events_callback(context)
+
+        event1.mark_complete.assert_called_once()
+        event2.mark_complete.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 from telegram.error import TelegramError
 
 from ongabot import ongabot
+from ongabot.ongabot import post_init
 
 
 class CompletePastEventsCallbackTest(unittest.IsolatedAsyncioTestCase):
@@ -56,6 +57,19 @@ class CompletePastEventsHappyPathTest(unittest.IsolatedAsyncioTestCase):
         event.mark_complete.assert_called_once()
         event.update_status_message.assert_called_once_with(context.bot)
         chat.remove_pinned_poll.assert_called_once_with("poll1")
+
+
+class PostInitSchedulingFailsTest(unittest.IsolatedAsyncioTestCase):
+    async def test_no_exception_propagates_when_schedule_all_event_jobs_raises(self):
+        application = MagicMock()
+        application.bot_data.schedule_all_event_jobs.side_effect = Exception("corrupt data")
+        application.job_queue = MagicMock()
+
+        # Should not raise
+        await post_init(application)
+
+        application.job_queue.run_once.assert_called_once()
+        application.job_queue.run_daily.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -36,6 +36,31 @@ class CompletePastEventsCallbackTest(unittest.IsolatedAsyncioTestCase):
         # Both events should be unpinned regardless of the status message failure
         self.assertEqual(chat.remove_pinned_poll.call_count, 2)
 
+    async def test_second_event_processed_when_first_remove_pinned_poll_raises(self):
+        event1 = MagicMock()
+        event1.completed = False
+        event1.event_date = date(2020, 1, 1)
+        event1.poll_id = "poll1"
+        event1.update_status_message = AsyncMock()
+
+        event2 = MagicMock()
+        event2.completed = False
+        event2.event_date = date(2020, 1, 2)
+        event2.poll_id = "poll2"
+        event2.update_status_message = AsyncMock()
+
+        chat = MagicMock()
+        chat.events = {"poll1": event1, "poll2": event2}
+        chat.remove_pinned_poll = AsyncMock(side_effect=[TelegramError("forbidden"), None])
+
+        context = MagicMock()
+        context.bot_data.chats = {"chat1": chat}
+
+        await ongabot.complete_past_events_callback(context)
+
+        event1.mark_complete.assert_called_once()
+        event2.mark_complete.assert_called_once()
+
 
 class CompletePastEventsHappyPathTest(unittest.IsolatedAsyncioTestCase):
     async def test_events_completed_and_unpinned_on_success(self):

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -32,6 +32,30 @@ class CompletePastEventsCallbackTest(unittest.IsolatedAsyncioTestCase):
 
         event1.mark_complete.assert_called_once()
         event2.mark_complete.assert_called_once()
+        # Both events should be unpinned regardless of the status message failure
+        self.assertEqual(chat.remove_pinned_poll.call_count, 2)
+
+
+class CompletePastEventsHappyPathTest(unittest.IsolatedAsyncioTestCase):
+    async def test_events_completed_and_unpinned_on_success(self):
+        event = MagicMock()
+        event.completed = False
+        event.event_date = date(2020, 1, 1)
+        event.poll_id = "poll1"
+        event.update_status_message = AsyncMock()
+
+        chat = MagicMock()
+        chat.events = {"poll1": event}
+        chat.remove_pinned_poll = AsyncMock()
+
+        context = MagicMock()
+        context.bot_data.chats = {"chat1": chat}
+
+        await ongabot.complete_past_events_callback(context)
+
+        event.mark_complete.assert_called_once()
+        event.update_status_message.assert_called_once_with(context.bot)
+        chat.remove_pinned_poll.assert_called_once_with("poll1")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- **I7a** — Wrap `send_poll` (fatal), `send_status_message` (non-fatal), and `pin` (non-fatal) in `create_event` with `try/except TelegramError`; a poll-send failure aborts creation, status/pin failures are logged and the event is still registered
- **I7b** — Wrap `update_status_message` and `remove_pinned_poll` per-event in `complete_past_events_callback` so a single chat's API failure doesn't abort processing of all other chats
- **I8** — Wrap `schedule_all_event_jobs` in `post_init` with `try/except Exception`; on corrupt persisted data the bot still starts and logs a clear error

## Test Plan
- [x] `make test` passes (81 tests, 56% coverage)
- [x] `make check` passes (pylint 10/10, mypy, flake8, black clean)
- [x] New test files: `tests/test_eventcreator.py`, `tests/test_ongabot.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)