### PR TITLE
feat: register bot metadata (commands, description) at startup

### DIFF
--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -5,6 +5,7 @@ import datetime
 import logging
 import os
 
+from telegram import Bot, BotCommand
 from telegram.ext import Application, CallbackContext, ContextTypes, PicklePersistence
 from telegram.error import TelegramError
 
@@ -26,6 +27,7 @@ from handler import StartCommandHandler
 from handler import UpdateEventCommandHandler
 from userdata import UserData
 from utils import log
+from utils.commands import ALL_COMMANDS, BOT_DESCRIPTION, BOT_SHORT_DESCRIPTION
 
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO").upper(),
@@ -69,6 +71,26 @@ async def complete_past_events_callback(context: CallbackContext) -> None:
                     event.event_date,
                     chat.chat_id,
                 )
+
+
+async def setup_bot_metadata(bot: Bot) -> None:
+    """Register command menu, description, and short description with Telegram."""
+    commands = [BotCommand(cmd.command, cmd.menu_description) for cmd in ALL_COMMANDS]
+    try:
+        await bot.set_my_commands(commands)
+        logger.info("Bot commands registered (%d commands)", len(commands))
+    except TelegramError as e:
+        logger.error("Failed to set bot commands: %s", e)
+    try:
+        await bot.set_my_description(BOT_DESCRIPTION)
+        logger.info("Bot description registered")
+    except TelegramError as e:
+        logger.error("Failed to set bot description: %s", e)
+    try:
+        await bot.set_my_short_description(BOT_SHORT_DESCRIPTION)
+        logger.info("Bot short description registered")
+    except TelegramError as e:
+        logger.error("Failed to set bot short description: %s", e)
 
 
 async def post_init(application: Application) -> None:

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -120,6 +120,8 @@ async def post_init(application: Application) -> None:
         complete_past_events_callback, time=datetime.time(0, 0, 0), name="complete_past_events"
     )
 
+    await setup_bot_metadata(application.bot)
+
 
 async def error(update: object, context: CallbackContext) -> None:
     """Log Errors caused by Updates."""

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -102,6 +102,8 @@ async def post_init(application: Application) -> None:
         if raw_id.strip().lstrip("-").isdigit():
             bot_data.authorize_chat(int(raw_id.strip()))
 
+    await setup_bot_metadata(application.bot)
+
     if application.job_queue is None:
         logger.error("Job queue is not available in post_init. Event cleanup jobs will not be scheduled.")
         return
@@ -119,8 +121,6 @@ async def post_init(application: Application) -> None:
     application.job_queue.run_daily(
         complete_past_events_callback, time=datetime.time(0, 0, 0), name="complete_past_events"
     )
-
-    await setup_bot_metadata(application.bot)
 
 
 async def error(update: object, context: CallbackContext) -> None:

--- a/ongabot/utils/commands.py
+++ b/ongabot/utils/commands.py
@@ -47,7 +47,7 @@ NEWEVENT = CommandInfo(
         "  /newevent day=friday\n"
         "  /newevent day=friday time=19:00 slots=3"
     ),
-    menu_description="Create event poll [day] [time] [slots]",
+    menu_description="Create event poll [day=..] [time=..] [slots=..]",
 )
 
 CANCELEVENT = CommandInfo(
@@ -62,7 +62,7 @@ CANCELEVENT = CommandInfo(
         "  /cancelevent target_date=wednesday\n"
         "  /cancelevent target_date=2026-05-10"
     ),
-    menu_description="Cancel active event [target_date]",
+    menu_description="Cancel active event [target_date=..]",
 )
 
 UPDATEEVENT = CommandInfo(
@@ -82,7 +82,7 @@ UPDATEEVENT = CommandInfo(
         "  /updateevent target_date=2026-05-07 day=2026-05-14\n"
         "  /updateevent target_date=2026-05-07 time=20:00 slots=4"
     ),
-    menu_description="Update active event [target_date] [day] [time] [slots]",
+    menu_description="Update active event [target_date=..] [day=..] [time=..] [slots=..]",
 )
 
 SCHEDULE = CommandInfo(
@@ -100,7 +100,7 @@ SCHEDULE = CommandInfo(
         "  /schedule trigger_on=sunday day=wednesday\n"
         "  /schedule trigger_on=sunday day=wednesday time=19:00 slots=4"
     ),
-    menu_description="Schedule weekly polls [trigger_on] [day] [time] [slots]",
+    menu_description="Schedule weekly polls [trigger_on=..] [day=..] [time=..] [slots=..]",
 )
 
 RESCHEDULE = CommandInfo(
@@ -117,7 +117,7 @@ RESCHEDULE = CommandInfo(
         "  /reschedule time=20:00\n"
         "  /reschedule trigger_on=monday day=thursday"
     ),
-    menu_description="Update weekly schedule [trigger_on] [day] [time] [slots]",
+    menu_description="Update weekly schedule [trigger_on=..] [day=..] [time=..] [slots=..]",
 )
 
 DESCHEDULE = CommandInfo(

--- a/ongabot/utils/commands.py
+++ b/ongabot/utils/commands.py
@@ -16,18 +16,21 @@ class CommandInfo:
     command: str
     brief: str  # one-liner shown in /help
     usage: str  # multi-line shown on bad input
+    menu_description: str  # short phrase shown in Telegram command menu
 
 
 HELP = CommandInfo(
     command="help",
     brief="/help - Get some aid in needing times",
     usage="/help",
+    menu_description="Get some aid in needing times",
 )
 
 ONGA = CommandInfo(
     command="onga",
     brief="/onga - This is the way, let me show you",
     usage="/onga",
+    menu_description="This is the way, let me show you",
 )
 
 NEWEVENT = CommandInfo(
@@ -44,6 +47,7 @@ NEWEVENT = CommandInfo(
         "  /newevent day=friday\n"
         "  /newevent day=friday time=19:00 slots=3"
     ),
+    menu_description="Create event poll [day] [time] [slots]",
 )
 
 CANCELEVENT = CommandInfo(
@@ -58,6 +62,7 @@ CANCELEVENT = CommandInfo(
         "  /cancelevent target_date=wednesday\n"
         "  /cancelevent target_date=2026-05-10"
     ),
+    menu_description="Cancel active event [target_date]",
 )
 
 UPDATEEVENT = CommandInfo(
@@ -77,6 +82,7 @@ UPDATEEVENT = CommandInfo(
         "  /updateevent target_date=2026-05-07 day=2026-05-14\n"
         "  /updateevent target_date=2026-05-07 time=20:00 slots=4"
     ),
+    menu_description="Update active event [target_date] [day] [time] [slots]",
 )
 
 SCHEDULE = CommandInfo(
@@ -94,6 +100,7 @@ SCHEDULE = CommandInfo(
         "  /schedule trigger_on=sunday day=wednesday\n"
         "  /schedule trigger_on=sunday day=wednesday time=19:00 slots=4"
     ),
+    menu_description="Schedule weekly polls [trigger_on] [day] [time] [slots]",
 )
 
 RESCHEDULE = CommandInfo(
@@ -110,24 +117,36 @@ RESCHEDULE = CommandInfo(
         "  /reschedule time=20:00\n"
         "  /reschedule trigger_on=monday day=thursday"
     ),
+    menu_description="Update weekly schedule [trigger_on] [day] [time] [slots]",
 )
 
 DESCHEDULE = CommandInfo(
     command="deschedule",
     brief="/deschedule - Remove the weekly schedule",
     usage="/deschedule",
+    menu_description="Remove the weekly schedule",
 )
 
 AUTHORIZE = CommandInfo(
     command="authorize",
     brief="/authorize - Authorize this chat to use ONGAbot (bot admins only)",
     usage="/authorize",
+    menu_description="Authorize this chat (admins only)",
 )
 
 DEAUTHORIZE = CommandInfo(
     command="deauthorize",
     brief="/deauthorize - Deauthorize this chat from using ONGAbot (bot admins only)",
     usage="/deauthorize",
+    menu_description="Deauthorize this chat (admins only)",
+)
+
+BOT_SHORT_DESCRIPTION = "Recurring event polls for group chats"
+
+BOT_DESCRIPTION = (
+    "ONGAbot helps group chats organize recurring events with Telegram polls. "
+    "Create event polls, manage weekly schedules, and track participation — "
+    "all without leaving your chat."
 )
 
 # Ordered for help text assembly

--- a/ongabot/utils/commands.py
+++ b/ongabot/utils/commands.py
@@ -141,7 +141,7 @@ DEAUTHORIZE = CommandInfo(
     menu_description="Deauthorize this chat (admins only)",
 )
 
-BOT_SHORT_DESCRIPTION = "Recurring event polls for group chats"
+BOT_SHORT_DESCRIPTION = "ONGAbot - the only bot you'll ever need"
 
 BOT_DESCRIPTION = (
     "ONGAbot helps group chats organize recurring events with Telegram polls. "

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,6 +1,6 @@
 import unittest
 
-from utils.commands import ALL_COMMANDS, BOT_DESCRIPTION, BOT_SHORT_DESCRIPTION
+from ongabot.utils.commands import ALL_COMMANDS, BOT_DESCRIPTION, BOT_SHORT_DESCRIPTION
 
 
 class CommandInfoMenuDescriptionTest(unittest.TestCase):
@@ -13,6 +13,10 @@ class CommandInfoMenuDescriptionTest(unittest.TestCase):
 
     def test_bot_description_within_telegram_limit(self):
         self.assertLessEqual(len(BOT_DESCRIPTION), 512)
+
+    def test_all_commands_menu_description_within_telegram_limit(self):
+        for cmd in ALL_COMMANDS:
+            self.assertLessEqual(len(cmd.menu_description), 256, f"{cmd.command} menu_description too long")
 
 
 if __name__ == "__main__":

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,19 @@
+import unittest
+
+from utils.commands import ALL_COMMANDS, BOT_DESCRIPTION, BOT_SHORT_DESCRIPTION
+
+
+class CommandInfoMenuDescriptionTest(unittest.TestCase):
+    def test_all_commands_have_menu_description(self):
+        for cmd in ALL_COMMANDS:
+            self.assertTrue(cmd.menu_description, f"{cmd.command} missing menu_description")
+
+    def test_bot_short_description_within_telegram_limit(self):
+        self.assertLessEqual(len(BOT_SHORT_DESCRIPTION), 120)
+
+    def test_bot_description_within_telegram_limit(self):
+        self.assertLessEqual(len(BOT_DESCRIPTION), 512)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock
 from telegram.error import TelegramError
 
 from ongabot import ongabot
-from ongabot.ongabot import post_init
+from ongabot.ongabot import post_init, setup_bot_metadata
 
 
 class CompletePastEventsCallbackTest(unittest.IsolatedAsyncioTestCase):
@@ -95,6 +95,36 @@ class PostInitSchedulingFailsTest(unittest.IsolatedAsyncioTestCase):
 
         application.job_queue.run_once.assert_called_once()
         application.job_queue.run_daily.assert_called_once()
+
+
+class SetupBotMetadataTest(unittest.IsolatedAsyncioTestCase):
+    async def test_calls_all_three_api_methods_on_success(self):
+        bot = AsyncMock()
+        await setup_bot_metadata(bot)
+        bot.set_my_commands.assert_called_once()
+        bot.set_my_description.assert_called_once()
+        bot.set_my_short_description.assert_called_once()
+
+    async def test_continues_when_set_my_commands_raises(self):
+        bot = AsyncMock()
+        bot.set_my_commands.side_effect = TelegramError("network error")
+        await setup_bot_metadata(bot)  # must not raise
+        bot.set_my_description.assert_called_once()
+        bot.set_my_short_description.assert_called_once()
+
+    async def test_continues_when_set_my_description_raises(self):
+        bot = AsyncMock()
+        bot.set_my_description.side_effect = TelegramError("network error")
+        await setup_bot_metadata(bot)  # must not raise
+        bot.set_my_commands.assert_called_once()
+        bot.set_my_short_description.assert_called_once()
+
+    async def test_continues_when_set_my_short_description_raises(self):
+        bot = AsyncMock()
+        bot.set_my_short_description.side_effect = TelegramError("network error")
+        await setup_bot_metadata(bot)  # must not raise
+        bot.set_my_commands.assert_called_once()
+        bot.set_my_description.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -87,6 +87,7 @@ class CompletePastEventsHappyPathTest(unittest.IsolatedAsyncioTestCase):
 class PostInitSchedulingFailsTest(unittest.IsolatedAsyncioTestCase):
     async def test_no_exception_propagates_when_schedule_all_event_jobs_raises(self):
         application = MagicMock()
+        application.bot = AsyncMock()
         application.bot_data.schedule_all_event_jobs.side_effect = Exception("corrupt data")
         application.job_queue = MagicMock()
 
@@ -95,6 +96,20 @@ class PostInitSchedulingFailsTest(unittest.IsolatedAsyncioTestCase):
 
         application.job_queue.run_once.assert_called_once()
         application.job_queue.run_daily.assert_called_once()
+
+
+class PostInitMetadataWiringTest(unittest.IsolatedAsyncioTestCase):
+    async def test_post_init_registers_bot_metadata(self):
+        application = MagicMock()
+        application.bot_data.schedule_all_event_jobs.return_value = None
+        application.job_queue = MagicMock()
+        application.bot = AsyncMock()
+
+        await post_init(application)
+
+        application.bot.set_my_commands.assert_called_once()
+        application.bot.set_my_description.assert_called_once()
+        application.bot.set_my_short_description.assert_called_once()
 
 
 class SetupBotMetadataTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -111,6 +111,18 @@ class PostInitMetadataWiringTest(unittest.IsolatedAsyncioTestCase):
         application.bot.set_my_description.assert_called_once()
         application.bot.set_my_short_description.assert_called_once()
 
+    async def test_post_init_registers_bot_metadata_when_job_queue_unavailable(self):
+        application = MagicMock()
+        application.bot_data.schedule_all_event_jobs.return_value = None
+        application.job_queue = None
+        application.bot = AsyncMock()
+
+        await post_init(application)
+
+        application.bot.set_my_commands.assert_called_once()
+        application.bot.set_my_description.assert_called_once()
+        application.bot.set_my_short_description.assert_called_once()
+
 
 class SetupBotMetadataTest(unittest.IsolatedAsyncioTestCase):
     async def test_calls_all_three_api_methods_on_success(self):


### PR DESCRIPTION
## Summary
- Adds `menu_description` field to `CommandInfo` and `BOT_DESCRIPTION`/`BOT_SHORT_DESCRIPTION` constants in `utils/commands.py`
- Adds `setup_bot_metadata(bot)` async helper that calls `set_my_commands`, `set_my_description`, and `set_my_short_description` with isolated per-call error handling
- Wires into `post_init` before the `job_queue` guard so metadata always registers at startup, even when job scheduling is unavailable

## Test Plan
- [x] `make check && make test` passes (105 tests, 59% coverage)
- [x] Start bot locally with `make run`, confirm logs show `Bot commands registered (10 commands)`, `Bot description registered`, `Bot short description registered`
- [x] Type `/` in a Telegram chat with the bot — verify command menu shows all 10 commands with arg-hint descriptions
- [ ] Check bot profile page — short description and full description are set correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)