### PR TITLE
ci: add OCI metadata labels to Docker images, drop nightly tag

### DIFF
--- a/.github/workflows/_docker-build.yml
+++ b/.github/workflows/_docker-build.yml
@@ -17,6 +17,11 @@ on:
         required: false
         type: boolean
         default: true
+      version:
+        description: OCI version label (e.g. "1.0.2" for release, "1.0.2-abc1234" for edge)
+        required: false
+        type: string
+        default: ""
     secrets:
       DOCKERHUB_USERNAME:
         required: false
@@ -31,6 +36,20 @@ jobs:
       - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Get commit SHA
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ github.repository }}
+          labels: |
+            org.opencontainers.image.title=ONGAbot
+            org.opencontainers.image.version=${{ inputs.version }}
+            org.opencontainers.image.revision=${{ steps.commit.outputs.sha }}
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v4
@@ -50,3 +69,4 @@ jobs:
         with:
           push: ${{ inputs.push }}
           tags: ${{ inputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,22 +13,37 @@ on:
   pull_request:
 
 jobs:
+  compute-edge-version:
+    name: Compute edge version label
+    runs-on: ubuntu-latest
+    outputs:
+      version_label: ${{ steps.version.outputs.version_label }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: version
+        run: |
+          version=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py)
+          short_sha="${GITHUB_SHA::7}"
+          echo "version_label=${version}-${short_sha}" >> $GITHUB_OUTPUT
+
   edge:
     name: Build edge image
     if: github.event_name == 'push'
+    needs: [compute-edge-version]
     uses: ./.github/workflows/_docker-build.yml
     with:
       tags: ${{ github.repository }}:edge
+      version: ${{ needs.compute-edge-version.outputs.version_label }}
     secrets: inherit
 
   nightly-edge:
     name: Nightly master image
     if: github.event_name == 'schedule'
+    needs: [compute-edge-version]
     uses: ./.github/workflows/_docker-build.yml
     with:
-      tags: |
-        ${{ github.repository }}:edge
-        ${{ github.repository }}:nightly
+      tags: ${{ github.repository }}:edge
+      version: ${{ needs.compute-edge-version.outputs.version_label }}
     secrets: inherit
 
   find-latest-release:
@@ -56,13 +71,16 @@ jobs:
       tags: |
         ${{ github.repository }}:${{ needs.find-latest-release.outputs.version }}
         ${{ github.repository }}:latest
+      version: ${{ needs.find-latest-release.outputs.version }}
     secrets: inherit
 
   pr:
     name: Build PR image
     if: github.event_name == 'pull_request'
+    needs: [compute-edge-version]
     uses: ./.github/workflows/_docker-build.yml
     with:
       tags: ${{ github.repository }}:pr-${{ github.event.pull_request.number }}
+      version: ${{ needs.compute-edge-version.outputs.version_label }}
       push: false
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+- Docker images now include OCI metadata labels: `version`, `revision`, `created`, `source`, `title`
+  - Release images: `version` is the clean semver (e.g. `1.0.2`)
+  - Edge/PR images: `version` includes the short commit SHA (e.g. `1.0.2-abc1234`)
+- Removed redundant `nightly` Docker tag; `edge` is the single rolling non-release tag


### PR DESCRIPTION
## Summary
- Adds OCI standard labels (`version`, `revision`, `created`, `source`, `title`) to all Docker image builds via `docker/metadata-action@v5`
- Edge/PR builds: `version` = `1.0.2-{short_sha}` (app version + short commit SHA)
- Release builds: `version` = `1.0.2` (clean semver)
- Removes redundant `nightly` tag — `edge` is the sole rolling non-release tag

## Changes
- `.github/workflows/_docker-build.yml`: new `version` input; adds "Get commit SHA" and "Extract metadata" steps; passes `labels` to build-push-action
- `.github/workflows/docker.yml`: new `compute-edge-version` job reads version from `ongabot/_version.py` and combines with short SHA; all build jobs receive the version label; `nightly` tag removed from `nightly-edge`

## Test plan
- [x] PR CI run completes successfully
- [ ] After merge, push-to-master CI produces `edge` image — verify labels with `docker inspect tingvarsson/telegram.ongabot:edge --format '{{ json .Config.Labels }}'`
- [ ] Next scheduled run: `edge` and release images carry OCI labels; `nightly` tag no longer published

🤖 Generated with [Claude Code](https://claude.com/claude-code)