### PR TITLE
fix: recover event date from poll question during migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Migration of old polls no longer discards events due to date collisions on `0001-01-01`.
+  The real event date is now recovered from the poll question text (`When: YYYY-MM-DD HH:MM`).
+  For the rare case where parsing fails, duplicate events receive unique surrogate keys so
+  all poll statistics are preserved.
+
 ### Changed
 - Docker images now include OCI metadata labels: `version`, `revision`, `created`, `source`, `title`
   - Release images: `version` is the clean semver (e.g. `1.0.2`)

--- a/ongabot/chat.py
+++ b/ongabot/chat.py
@@ -1,7 +1,7 @@
 """This module contains the Chat class."""
 
 import logging
-from datetime import date
+from datetime import date, timedelta
 from typing import Callable, Dict, Optional
 
 from telegram import Message
@@ -63,6 +63,17 @@ class Chat:
                             "Date collision during migration: discarding completed poll_id=%s,"
                             " keeping active poll_id=%s for date=%s",
                             existing.poll_id,
+                            event.poll_id,
+                            d,
+                        )
+                        migrated[d] = event
+                    elif d == date.min:
+                        # Real date unknown for both events; assign unique surrogate key to preserve statistics
+                        while d in migrated:
+                            d += timedelta(days=1)
+                        _logger.warning(
+                            "Date collision on date.min for poll_id=%s;"
+                            " assigning surrogate date=%s to preserve statistics",
                             event.poll_id,
                             d,
                         )

--- a/ongabot/event.py
+++ b/ongabot/event.py
@@ -15,6 +15,22 @@ from utils import log
 _logger = logging.getLogger(__name__)
 
 
+def _parse_eventdata_from_poll_question(question: str) -> Optional[EventData]:
+    """Parse EventData from a poll question produced by _create_poll_text.
+
+    Format: "Event: <name>\nWhen: YYYY-MM-DD HH:MM"
+    Returns EventData on success, None on any parse failure.
+    """
+    try:
+        for line in question.splitlines():
+            if line.startswith("When: "):
+                date_str, time_str = line.removeprefix("When: ").split(" ", 1)
+                return EventData(date.fromisoformat(date_str), time.fromisoformat(time_str))
+        return None
+    except (ValueError, IndexError):
+        return None
+
+
 class Event:
     """
     The Event object represent an event and its poll
@@ -65,9 +81,25 @@ class Event:
         self.__dict__.update(state)
         # Set default values for any missing attributes (for backward compatibility with older persisted data)
         if not hasattr(self, "data"):
-            # date.min treated as already past, so that old events will be marked completed immediately on update
-            # and not show up as active events, otherwise assume default values for all fields
-            self.data = EventData(date.min)
+            # Try to recover the real date/time from the poll question before falling back to date.min.
+            # self.poll is always present on old events (it predates EventData).
+            parsed = _parse_eventdata_from_poll_question(self.poll.question)
+            if parsed is not None:
+                _logger.info(
+                    "Recovered EventData from poll question for poll_id=%s: date=%s time=%s",
+                    self.poll_id,
+                    parsed.event_date,
+                    parsed.start_time,
+                )
+                self.data = parsed
+            else:
+                # date.min treated as already past, so that old events will be marked completed immediately on update
+                # and not show up as active events
+                _logger.warning(
+                    "Could not parse EventData from poll question for poll_id=%s; falling back to date.min",
+                    self.poll_id,
+                )
+                self.data = EventData(date.min)
         if not hasattr(self, "completed"):
             # Assume old events are completed, aligned with date.min, to avoid showing them as active events after
             # a bot update

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -3,6 +3,7 @@ from datetime import date
 from unittest.mock import MagicMock
 
 from ongabot.chat import Chat
+from ongabot.event import Event
 
 
 def _make_event(poll_id: str, event_date: date, completed: bool = False, cancelled: bool = False):
@@ -140,6 +141,68 @@ class ChatSetStateMigrationTest(unittest.TestCase):
             }
         )
         self.assertEqual(chat._poll_id_index["p1"], date(2026, 6, 4))
+
+
+class ChatSetStateMigrationOldEventTest(unittest.TestCase):
+    def _make_real_old_event(self, poll_id: str, poll_question: str) -> Event:
+        """Build a real Event in pre-EventData state (no 'data' attribute)."""
+        poll = MagicMock()
+        poll.id = poll_id
+        poll.question = poll_question
+        state = {
+            "chat_id": 1,
+            "poll": poll,
+            "poll_id": poll_id,
+            "poll_answers": {},
+            "first_answer": None,
+            "status_message_id": 0,
+            # 'data', 'completed', 'cancelled', 'user_streaks' intentionally absent
+        }
+        event = Event.__new__(Event)
+        event.__setstate__(state)
+        return event
+
+    def test_two_old_events_with_different_dates_migrate_without_collision(self):
+        event1 = self._make_real_old_event("p1", "Event: TOGA (with ONGA)\nWhen: 2026-06-04 18:30")
+        event2 = self._make_real_old_event("p2", "Event: ONGA\nWhen: 2026-06-03 18:30")
+
+        chat = Chat.__new__(Chat)
+        chat.__setstate__(
+            {
+                "chat_id": 1,
+                "events": {"p1": event1, "p2": event2},
+                "event_job": None,
+                "pinned_polls": {},
+            }
+        )
+
+        self.assertEqual(len(chat.events), 2)
+        self.assertIn(date(2026, 6, 4), chat.events)
+        self.assertIn(date(2026, 6, 3), chat.events)
+        self.assertIs(chat.events[date(2026, 6, 4)], event1)
+        self.assertIs(chat.events[date(2026, 6, 3)], event2)
+
+    def test_two_old_events_with_unparseable_questions_both_kept_with_surrogate_keys(self):
+        event1 = self._make_real_old_event("p1", "no when line here")
+        event2 = self._make_real_old_event("p2", "also no when line")
+
+        chat = Chat.__new__(Chat)
+        chat.__setstate__(
+            {
+                "chat_id": 1,
+                "events": {"p1": event1, "p2": event2},
+                "event_job": None,
+                "pinned_polls": {},
+            }
+        )
+
+        # Both events must be kept — no discard
+        self.assertEqual(len(chat.events), 2)
+        # First event gets date.min, second gets the next surrogate date
+        from datetime import timedelta
+
+        self.assertIn(date.min, chat.events)
+        self.assertIn(date.min + timedelta(days=1), chat.events)
 
 
 if __name__ == "__main__":

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,5 +1,5 @@
 import unittest
-from datetime import date
+from datetime import date, timedelta
 from unittest.mock import MagicMock
 
 from ongabot.chat import Chat
@@ -199,8 +199,6 @@ class ChatSetStateMigrationOldEventTest(unittest.TestCase):
         # Both events must be kept — no discard
         self.assertEqual(len(chat.events), 2)
         # First event gets date.min, second gets the next surrogate date
-        from datetime import timedelta
-
         self.assertIn(date.min, chat.events)
         self.assertIn(date.min + timedelta(days=1), chat.events)
 

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,104 @@
+import unittest
+from datetime import date, time
+from unittest.mock import MagicMock
+
+from ongabot.event import Event
+from ongabot.eventdata import EventData
+
+
+def _make_old_state(poll_question: str, poll_id: str = "test_poll_id") -> dict:
+    """Minimal pre-EventData state dict for testing Event.__setstate__."""
+    poll = MagicMock()
+    poll.id = poll_id
+    poll.question = poll_question
+    return {
+        "chat_id": 1,
+        "poll": poll,
+        "poll_id": poll_id,
+        "poll_answers": {},
+        "first_answer": None,
+        "status_message_id": 0,
+        "completed": False,
+        "cancelled": False,
+        "user_streaks": {},
+        # 'data' intentionally absent to trigger migration path
+    }
+
+
+class EventSetStateParsesDateTest(unittest.TestCase):
+    def test_recovers_date_and_time_from_valid_poll_question(self):
+        state = _make_old_state("Event: TOGA (with ONGA)\nWhen: 2026-06-04 18:30")
+        event = Event.__new__(Event)
+        event.__setstate__(state)
+
+        self.assertEqual(event.data.event_date, date(2026, 6, 4))
+        self.assertEqual(event.data.start_time, time(18, 30))
+
+    def test_falls_back_to_date_min_when_no_when_line(self):
+        state = _make_old_state("Some unexpected format without When line")
+        event = Event.__new__(Event)
+        event.__setstate__(state)
+
+        self.assertEqual(event.data.event_date, date.min)
+
+    def test_falls_back_to_date_min_when_date_malformed(self):
+        state = _make_old_state("Event: ONGA\nWhen: not-a-date 18:30")
+        event = Event.__new__(Event)
+        event.__setstate__(state)
+
+        self.assertEqual(event.data.event_date, date.min)
+
+    def test_falls_back_to_date_min_when_time_malformed(self):
+        state = _make_old_state("Event: ONGA\nWhen: 2026-06-03 99:99")
+        event = Event.__new__(Event)
+        event.__setstate__(state)
+
+        self.assertEqual(event.data.event_date, date.min)
+
+    def test_existing_data_is_not_overwritten(self):
+        existing_data = EventData(date(2025, 1, 1), time(20, 0), 3)
+        poll = MagicMock()
+        poll.id = "p1"
+        poll.question = "Event: ONGA\nWhen: 2026-06-03 18:30"
+        state = {
+            "chat_id": 1,
+            "poll": poll,
+            "poll_id": "p1",
+            "poll_answers": {},
+            "first_answer": None,
+            "status_message_id": 0,
+            "completed": False,
+            "cancelled": False,
+            "user_streaks": {},
+            "data": existing_data,
+        }
+        event = Event.__new__(Event)
+        event.__setstate__(state)
+
+        self.assertIs(event.data, existing_data)
+
+
+class EventSetStateDefaultsTest(unittest.TestCase):
+    def test_completed_defaults_to_true_when_absent(self):
+        poll = MagicMock()
+        poll.id = "p1"
+        poll.question = "Event: ONGA\nWhen: 2026-06-03 18:30"
+        state = {
+            "chat_id": 1,
+            "poll": poll,
+            "poll_id": "p1",
+            "poll_answers": {},
+            "first_answer": None,
+            "status_message_id": 0,
+            # 'completed', 'cancelled', 'user_streaks', 'data' all absent
+        }
+        event = Event.__new__(Event)
+        event.__setstate__(state)
+
+        self.assertTrue(event.completed)
+        self.assertFalse(event.cancelled)
+        self.assertEqual(event.user_streaks, {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Old `Event` objects (pre-`EventData` era) all got `event_date = 0001-01-01` during deserialization, causing every old poll to collide on the same key when migrating to the date-keyed `Chat.events` dict — all but one were silently discarded
- `Event.__setstate__()` now parses the real date and start_time from the poll question text (`When: YYYY-MM-DD HH:MM`) before falling back to `date.min`
- As a second safety net, `Chat.__setstate__()` migration no longer discards events that collide on `date.min` — they receive unique surrogate keys (`date.min + 1`, `+2`, …) so all poll statistics are preserved

## Test Plan

- [x] `make test` passes (142 tests, 70% coverage)
- [x] Confirm log no longer shows `Date collision during migration: discarding poll_id=... for date=0001-01-01` when bot loads persisted state
- [x] New `tests/test_event.py` covers parse helper and `Event.__setstate__()` migration path
- [x] New `ChatSetStateMigrationOldEventTest` in `tests/test_chat.py` covers the no-collision and surrogate-key scenarios with real `Event` objects

🤖 Generated with [Claude Code](https://claude.com/claude-code)