### PR TITLE
feat: versioning observability (/changelog, version in /help, startup announcements)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,8 @@ LOG_LEVEL=INFO
 
 # Optional: path to the pickle persistence database (default: ongabot.db)
 DB_PATH=ongabot.db
+
+# Optional: path to CHANGELOG.md for the /changelog command and startup announcements
+# In Docker the file is copied to /ongabot/CHANGELOG.md (default, no override needed).
+# For local dev via 'make run', set to the repo-root file relative to where make is invoked:
+CHANGELOG_PATH=CHANGELOG.md

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - id: version
         run: |
-          version=$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py)
+          version=$(grep -oE '^__version__ = "[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
           short_sha="${GITHUB_SHA::7}"
           echo "version_label=${version}-${short_sha}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v6
       - id: version
         run: |
-          version=$(grep -oE '^__version__ = "[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+          version=$(python3 scripts/version.py --base)
           short_sha="${GITHUB_SHA::7}"
           echo "version_label=${version}-${short_sha}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -49,3 +49,43 @@ jobs:
         ${{ github.repository }}:${{ needs.tag.outputs.version }}
         ${{ github.repository }}:latest
     secrets: inherit
+
+  resume-dev:
+    name: Open resume-development PR
+    needs: tag
+    if: needs.tag.outputs.is_new_version == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: master
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Re-add +dev suffix
+        run: make post-release
+
+      - name: Open resume-development PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          VERSION="${{ needs.tag.outputs.version }}"
+          BRANCH="resume-dev/v$VERSION"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git commit -am "chore: resume development (${VERSION}+dev)"
+          git push --force origin "$BRANCH"
+          if gh pr view "$BRANCH" --json state --jq .state 2>/dev/null | grep -q OPEN; then
+            echo "PR already open for $BRANCH"
+          else
+            gh pr create --base master --head "$BRANCH" \
+              --title "chore: resume development (${VERSION}+dev)" \
+              --body "Automated follow-up to releasing v${VERSION}: re-adds the \`+dev\` suffix to ongabot/_version.py so master is marked as a development build again."
+          fi

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -31,6 +31,11 @@ jobs:
         id: tag
         run: |
           VERSION="${{ steps.version.outputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Version $VERSION is a development build (not a clean release); skipping tag/release"
+            echo "is_new_version=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           TAG="v$VERSION"
           if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "refs/tags/$TAG$"; then
             echo "Tag $TAG already exists, skipping release build"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -17,25 +17,17 @@ jobs:
 
       - name: Read version
         id: version
-        run: |
-          version=$(python -c "
-          import re, sys
-          m = re.search(r'__version__ = \"([^\"]+)\"', open('ongabot/_version.py').read())
-          if not m:
-              sys.exit('Could not find __version__ in ongabot/_version.py')
-          print(m.group(1))
-          ")
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(python3 scripts/version.py --base)" >> "$GITHUB_OUTPUT"
 
       - name: Tag new version
         id: tag
         run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Version $VERSION is a development build (not a clean release); skipping tag/release"
+          if python3 scripts/version.py --is-dev; then
+            echo "Development build (not a clean release); skipping tag/release"
             echo "is_new_version=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          VERSION="${{ steps.version.outputs.version }}"
           TAG="v$VERSION"
           if git ls-remote --tags origin "refs/tags/$TAG" | grep -q "refs/tags/$TAG$"; then
             echo "Tag $TAG already exists, skipping release build"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `/changelog` command shows the changelog entry for the current bot version
-- Version number displayed in `/help` output
-- Bot posts a changelog delta message to all authorized chats when a new version is detected at startup
-- `BotData.last_known_version` persists the last-seen version across restarts
+- `/changelog [n]` shows the n most recent changelog entries (default 1)
+- On development builds, `/changelog` shows the `[Unreleased]` section
+- `/help` marks development builds with `(development build)` after the version
+- `BotData.last_known_version` persists the last-seen release across restarts
+
+### Changed
+
+- Startup version announcement is skipped on development builds and only fires on
+  clean release upgrades
+- Deployments predating version tracking are migrated to a `1.2.0` starting point so
+  the next release announces its delta
+- Development builds carry a `+dev` version suffix (e.g. `1.2.0+dev`)
 
 ## [1.2.0] - 2026-05-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/changelog` command shows the changelog entry for the current bot version
+- Version number displayed in `/help` output
+- Bot posts a changelog delta message to all authorized chats when a new version is detected at startup
+- `BotData.last_known_version` persists the last-seen version across restarts
+
 ## [1.2.0] - 2026-05-24
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ongabot /ongabot
+COPY CHANGELOG.md /ongabot/CHANGELOG.md
 
 ENV API_TOKEN=''
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ docker-run: .env
 
 release: check test
 	bump-my-version bump $(PART) && \
-	NEW_VERSION=$$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py) && \
+	NEW_VERSION=$$(grep -oE '^__version__ = "[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') && \
 	python scripts/update_changelog.py $$NEW_VERSION && \
 	git add CHANGELOG.md && \
 	git commit -m "docs: update CHANGELOG for v$$NEW_VERSION" && \
@@ -73,6 +73,6 @@ release: check test
 	gh pr create --title "chore: bump version to $$NEW_VERSION" --body "Release v$$NEW_VERSION" --base master --head $$BRANCH
 
 post-release:
-	@NEW_VERSION=$$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py) && \
-	sed -i "s/^__version__ = \"$$NEW_VERSION\"/__version__ = \"$$NEW_VERSION+dev\"/" ongabot/_version.py && \
+	@NEW_VERSION=$$(grep -oE '^__version__ = "[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') && \
+	sed -i -E "s/^__version__ = \"$$NEW_VERSION\"\$$/__version__ = \"$$NEW_VERSION+dev\"/" ongabot/_version.py && \
 	echo "Set development version $$NEW_VERSION+dev in ongabot/_version.py"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ VENV_PATH=venv
 
 export PYTHONPATH=$PYTHONPATH:./ongabot
 
-.PHONY: venv install run lint pep8 mypy black-check check black test clean docker-build docker-run release
+.PHONY: venv install run lint pep8 mypy black-check check black test clean docker-build docker-run release post-release
 
 .env:
 	@echo "Error: .env not found. Copy .env.example and fill in your values: cp .env.example .env"
@@ -71,3 +71,8 @@ release: check test
 	BRANCH="release/v$$NEW_VERSION" && \
 	git push origin HEAD:refs/heads/$$BRANCH && \
 	gh pr create --title "chore: bump version to $$NEW_VERSION" --body "Release v$$NEW_VERSION" --base master --head $$BRANCH
+
+post-release:
+	@NEW_VERSION=$$(grep -oE '[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py) && \
+	sed -i "s/^__version__ = \"$$NEW_VERSION\"/__version__ = \"$$NEW_VERSION+dev\"/" ongabot/_version.py && \
+	echo "Set development version $$NEW_VERSION+dev in ongabot/_version.py"

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,8 @@ install:
 	$(PIP) install -r requirements-dev.txt
 
 run: .env
-	set -a && . ./.env && set +a && $(PYTHON) ongabot/ongabot.py
+	set -a && . ./.env && set +a && \
+	CHANGELOG_PATH=$${CHANGELOG_PATH:-$(CURDIR)/CHANGELOG.md} $(PYTHON) ongabot/ongabot.py
 
 lint:
 	$(PYLINT) ongabot

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ docker-run: .env
 
 release: check test
 	bump-my-version bump $(PART) && \
-	NEW_VERSION=$$(grep -oE '^__version__ = "[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') && \
+	NEW_VERSION=$$(python scripts/version.py --base) && \
 	python scripts/update_changelog.py $$NEW_VERSION && \
 	git add CHANGELOG.md && \
 	git commit -m "docs: update CHANGELOG for v$$NEW_VERSION" && \
@@ -73,6 +73,6 @@ release: check test
 	gh pr create --title "chore: bump version to $$NEW_VERSION" --body "Release v$$NEW_VERSION" --base master --head $$BRANCH
 
 post-release:
-	@NEW_VERSION=$$(grep -oE '^__version__ = "[0-9]+\.[0-9]+\.[0-9]+' ongabot/_version.py | grep -oE '[0-9]+\.[0-9]+\.[0-9]+') && \
+	@NEW_VERSION=$$(python scripts/version.py --base) && \
 	sed -i -E "s/^__version__ = \"$$NEW_VERSION\"\$$/__version__ = \"$$NEW_VERSION+dev\"/" ongabot/_version.py && \
 	echo "Set development version $$NEW_VERSION+dev in ongabot/_version.py"

--- a/conftest.py
+++ b/conftest.py
@@ -1,8 +1,0 @@
-import sys
-from pathlib import Path
-
-# Add ongabot directory to sys.path to enable imports like "from event import Event"
-# This matches the project's import style
-ongabot_path = Path(__file__).parent / "ongabot"
-if str(ongabot_path) not in sys.path:
-    sys.path.insert(0, str(ongabot_path))

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Add ongabot directory to sys.path to enable imports like "from event import Event"
+# This matches the project's import style
+ongabot_path = Path(__file__).parent / "ongabot"
+if str(ongabot_path) not in sys.path:
+    sys.path.insert(0, str(ongabot_path))

--- a/ongabot/_version.py
+++ b/ongabot/_version.py
@@ -1,3 +1,8 @@
-"""The module defines the version(s) of ONGAbot."""
+"""The module defines the version(s) of ONGAbot.
 
-__version__ = "1.2.0"
+Between releases this carries a "+dev" build-metadata suffix on the last released
+version (e.g. "1.2.0+dev"), marking a development build. `make release` strips the
+suffix to produce the clean release; `make post-release` re-adds it to the new base.
+"""
+
+__version__ = "1.2.0+dev"

--- a/ongabot/botdata.py
+++ b/ongabot/botdata.py
@@ -16,8 +16,6 @@ class BotData:
     """
     The BotData object represent all persistent data stored for the bot
 
-    Args:
-
     Attributes:
         chats: Dict of Chat objects indexed by chat_id
         authorized_chats: Set of chat IDs allowed to use the bot

--- a/ongabot/botdata.py
+++ b/ongabot/botdata.py
@@ -35,7 +35,10 @@ class BotData:
             # when deploying the bot with persistence for the first time
             self.authorized_chats = set()
         if not hasattr(self, "last_known_version"):
-            self.last_known_version = None
+            # Deployments predating version tracking are seeded with the known starting
+            # point (1.2.0, the release in which tracking shipped) instead of None, so
+            # the next real release announces the delta rather than recording silently.
+            self.last_known_version = "1.2.0"
 
     def __repr__(self) -> str:
         return str(self.__class__) + ": " + str(self.__dict__)

--- a/ongabot/botdata.py
+++ b/ongabot/botdata.py
@@ -21,11 +21,13 @@ class BotData:
     Attributes:
         chats: Dict of Chat objects indexed by chat_id
         authorized_chats: Set of chat IDs allowed to use the bot
+        last_known_version: Version string of the last bot startup, used to detect upgrades
     """
 
     def __init__(self) -> None:
         self.chats: Dict[int, Chat] = {}
         self.authorized_chats: Set[int] = set()
+        self.last_known_version: str | None = None
 
     def __setstate__(self, state: Dict) -> None:
         self.__dict__.update(state)
@@ -34,6 +36,8 @@ class BotData:
             # Old chats are not authorized by default, to avoid accidentally authorizing all existing chats
             # when deploying the bot with persistence for the first time
             self.authorized_chats = set()
+        if not hasattr(self, "last_known_version"):
+            self.last_known_version = None
 
     def __repr__(self) -> str:
         return str(self.__class__) + ": " + str(self.__dict__)

--- a/ongabot/handler/__init__.py
+++ b/ongabot/handler/__init__.py
@@ -3,6 +3,7 @@
 from .authorizationhandler import AuthorizationHandler
 from .authorizecommandhandler import AuthorizeCommandHandler
 from .canceleventcommandhandler import CancelEventCommandHandler
+from .changelogcommandhandler import ChangelogCommandHandler
 from .deauthorizecommandhandler import DeAuthorizeCommandHandler
 from .deschedulecommandhandler import DeScheduleCommandHandler
 from .eventpollanswerhandler import EventPollAnswerHandler
@@ -19,6 +20,7 @@ __all__ = (
     "AuthorizationHandler",
     "AuthorizeCommandHandler",
     "CancelEventCommandHandler",
+    "ChangelogCommandHandler",
     "DeAuthorizeCommandHandler",
     "DeScheduleCommandHandler",
     "EventPollAnswerHandler",

--- a/ongabot/handler/changelogcommandhandler.py
+++ b/ongabot/handler/changelogcommandhandler.py
@@ -1,0 +1,26 @@
+"""This module contains the ChangelogCommandHandler class."""
+
+import logging
+
+from telegram import Update
+from telegram.ext import CallbackContext, CommandHandler
+
+from _version import __version__
+from utils.changelog import get_version_entry
+from utils.log import log
+
+_logger = logging.getLogger(__name__)
+
+
+class ChangelogCommandHandler(CommandHandler):
+    """Handler for /changelog command."""
+
+    def __init__(self) -> None:
+        super().__init__("changelog", callback)
+
+
+@log
+async def callback(update: Update, _: CallbackContext) -> None:
+    """Reply with the changelog entry for the current bot version."""
+    entry = get_version_entry(__version__)
+    await update.message.reply_text(entry)

--- a/ongabot/handler/changelogcommandhandler.py
+++ b/ongabot/handler/changelogcommandhandler.py
@@ -6,7 +6,8 @@ from telegram import Update
 from telegram.ext import CallbackContext, CommandHandler
 
 from _version import __version__
-from utils.changelog import get_version_entry
+from utils.changelog import get_changelog
+from utils.commands import CHANGELOG
 from utils.log import log
 
 _logger = logging.getLogger(__name__)
@@ -20,7 +21,14 @@ class ChangelogCommandHandler(CommandHandler):
 
 
 @log
-async def callback(update: Update, _: CallbackContext) -> None:
-    """Reply with the changelog entry for the current bot version."""
-    entry = get_version_entry(__version__)
+async def callback(update: Update, context: CallbackContext) -> None:
+    """Reply with the last N changelog entries (default 1) as seen from this build."""
+    count = 1
+    if context.args:
+        arg = context.args[0]
+        if not arg.isdigit() or int(arg) < 1:
+            await update.message.reply_text(CHANGELOG.usage)
+            return
+        count = int(arg)
+    entry = get_changelog(__version__, count)
     await update.message.reply_text(entry)

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -29,7 +29,7 @@ from handler import StartCommandHandler
 from handler import UpdateEventCommandHandler
 from userdata import UserData
 from utils import log
-from utils.changelog import get_changelog_delta
+from utils.changelog import get_changelog_delta, is_dev_version
 from utils.commands import ALL_COMMANDS, BOT_DESCRIPTION, BOT_SHORT_DESCRIPTION
 
 logging.basicConfig(
@@ -123,7 +123,11 @@ async def post_init(application: Application) -> None:
     await setup_bot_metadata(application.bot)
 
     stored_version = bot_data.last_known_version
-    if stored_version is None:
+    if is_dev_version(CURRENT_VERSION):
+        # Development build: never announce and never overwrite the last known
+        # release, so the next real release still announces the full delta.
+        logger.info("Development build %s — skipping version announcement", CURRENT_VERSION)
+    elif stored_version is None:
         # First startup after version tracking was introduced; record silently
         logger.info("Initializing version tracking at %s", CURRENT_VERSION)
         bot_data.last_known_version = CURRENT_VERSION

--- a/ongabot/ongabot.py
+++ b/ongabot/ongabot.py
@@ -10,10 +10,12 @@ from telegram.ext import Application, CallbackContext, ContextTypes, PicklePersi
 from telegram.error import TelegramError
 
 import eventcreator
+from _version import __version__ as CURRENT_VERSION
 from botdata import BotData
 from handler import AuthorizationHandler
 from handler import AuthorizeCommandHandler
 from handler import CancelEventCommandHandler
+from handler import ChangelogCommandHandler
 from handler import DeAuthorizeCommandHandler
 from handler import DeScheduleCommandHandler
 from handler import EventPollAnswerHandler
@@ -27,6 +29,7 @@ from handler import StartCommandHandler
 from handler import UpdateEventCommandHandler
 from userdata import UserData
 from utils import log
+from utils.changelog import get_changelog_delta
 from utils.commands import ALL_COMMANDS, BOT_DESCRIPTION, BOT_SHORT_DESCRIPTION
 
 logging.basicConfig(
@@ -93,6 +96,21 @@ async def setup_bot_metadata(bot: Bot) -> None:
         logger.error("Failed to set bot short description: %s", e)
 
 
+async def _announce_new_version(bot: Bot, bot_data: BotData, old_version: str, new_version: str) -> None:
+    """Send a version-change announcement to all authorized chats."""
+    delta = get_changelog_delta(old_version, new_version)
+    text = f"ONGAbot updated to v{new_version}!\n\n{delta}"
+    # Truncate to Telegram's 4096-character message limit
+    if len(text) > 4096:
+        text = text[:4090] + "\n..."
+    for chat_id in bot_data.authorized_chats:
+        try:
+            await bot.send_message(chat_id=chat_id, text=text)
+            logger.info("Sent version announcement to chat_id=%s", chat_id)
+        except TelegramError as e:
+            logger.error("Failed to send version announcement to chat_id=%s: %s", chat_id, e)
+
+
 async def post_init(application: Application) -> None:
     """Called after the application initializes with persistence loaded."""
     bot_data: BotData = application.bot_data
@@ -103,6 +121,16 @@ async def post_init(application: Application) -> None:
             bot_data.authorize_chat(int(raw_id.strip()))
 
     await setup_bot_metadata(application.bot)
+
+    stored_version = bot_data.last_known_version
+    if stored_version is None:
+        # First startup after version tracking was introduced; record silently
+        logger.info("Initializing version tracking at %s", CURRENT_VERSION)
+        bot_data.last_known_version = CURRENT_VERSION
+    elif stored_version != CURRENT_VERSION:
+        logger.info("Version change detected: %s → %s", stored_version, CURRENT_VERSION)
+        await _announce_new_version(application.bot, bot_data, stored_version, CURRENT_VERSION)
+        bot_data.last_known_version = CURRENT_VERSION
 
     if application.job_queue is None:
         logger.error("Job queue is not available in post_init. Event cleanup jobs will not be scheduled.")
@@ -156,6 +184,7 @@ def main() -> None:
     application.add_handler(DeAuthorizeCommandHandler())
     application.add_handler(StartCommandHandler())
     application.add_handler(HelpCommandHandler())
+    application.add_handler(ChangelogCommandHandler())
     application.add_handler(OngaCommandHandler())
     application.add_handler(NewEventCommandHandler())
     application.add_handler(CancelEventCommandHandler())

--- a/ongabot/utils/changelog.py
+++ b/ongabot/utils/changelog.py
@@ -106,8 +106,3 @@ def get_changelog(version: str, count: int = 1, changelog_path: Path = CHANGELOG
     end_pos = matches[end_section_idx].start() if end_section_idx < len(matches) else len(content)
 
     return content[start_pos:end_pos].strip()
-
-
-def get_version_entry(version: str, changelog_path: Path = CHANGELOG_PATH) -> str:
-    """Return the changelog entry for a single version."""
-    return get_changelog_delta(None, version, changelog_path)

--- a/ongabot/utils/changelog.py
+++ b/ongabot/utils/changelog.py
@@ -17,10 +17,46 @@ _VERSION_HEADER_RE = re.compile(r"^## \[([^\]]+)\]", re.MULTILINE)
 # "1.2.0+dev" build-metadata suffix) marks a development build.
 _RELEASE_VERSION_RE = re.compile(r"\d+\.\d+\.\d+")
 
+# A Keep-a-Changelog link-reference definition line, e.g.:
+#   [1.2.0]: https://github.com/org/repo/compare/v1.1.0...v1.2.0
+# These trail the last section in the real CHANGELOG.md and must never be
+# included as part of a returned section's body.
+_LINK_DEF_RE = re.compile(r"^\[[^\]]+\]:\s+\S+", re.MULTILINE)
+
 
 def is_dev_version(version: str) -> bool:
     """Return True if version is a development build (not a clean X.Y.Z release)."""
     return _RELEASE_VERSION_RE.fullmatch(version) is None
+
+
+def _effective_end(content: str) -> int:
+    """Return the index where "real" content ends, excluding a trailing link-reference block.
+
+    Keep-a-Changelog files end with a block of `[version]: url` link-definition
+    lines. When a returned section reaches end-of-file, that block must not be
+    swept into the output. This scans backward from the end of the file over a
+    contiguous run of link-definition lines (and blank lines immediately before
+    them) and returns the index where that trailing block begins. If there is no
+    such trailing block, returns len(content).
+    """
+    lines = content.splitlines(keepends=True)
+    end_idx = len(lines)  # index (into lines) of the effective end, in "lines" units
+    i = len(lines)
+    seen_link_def = False
+    while i > 0:
+        line = lines[i - 1]
+        if _LINK_DEF_RE.match(line):
+            seen_link_def = True
+            i -= 1
+            continue
+        if seen_link_def and line.strip() == "":
+            # Blank line directly above (or between) link-def lines: keep scanning back.
+            i -= 1
+            continue
+        break
+    if seen_link_def:
+        end_idx = i
+    return sum(len(line) for line in lines[:end_idx])
 
 
 def get_changelog_delta(
@@ -71,7 +107,7 @@ def get_changelog_delta(
     elif new_idx + 1 < len(matches):
         end_pos = matches[new_idx + 1].start()
     else:
-        end_pos = len(content)
+        end_pos = _effective_end(content)
 
     return content[start_pos:end_pos].strip()
 
@@ -103,6 +139,6 @@ def get_changelog(version: str, count: int = 1, changelog_path: Path = CHANGELOG
     count = max(1, count)
     end_section_idx = start_idx + count  # exclusive index into matches
     start_pos = matches[start_idx].start()
-    end_pos = matches[end_section_idx].start() if end_section_idx < len(matches) else len(content)
+    end_pos = matches[end_section_idx].start() if end_section_idx < len(matches) else _effective_end(content)
 
     return content[start_pos:end_pos].strip()

--- a/ongabot/utils/changelog.py
+++ b/ongabot/utils/changelog.py
@@ -4,7 +4,6 @@ import logging
 import os
 import re
 from pathlib import Path
-from typing import Optional
 
 _logger = logging.getLogger(__name__)
 
@@ -16,7 +15,7 @@ _VERSION_HEADER_RE = re.compile(r"^## \[([^\]]+)\]", re.MULTILINE)
 
 
 def get_changelog_delta(
-    old_version: Optional[str],
+    old_version: str | None,
     new_version: str,
     changelog_path: Path = CHANGELOG_PATH,
 ) -> str:
@@ -40,8 +39,13 @@ def get_changelog_delta(
         _logger.warning("Version %s not found in changelog", new_version)
         return f"ONGAbot updated to v{new_version}. (No changelog entry found)"
 
+    # Guard: same version produces empty delta
+    if old_version is not None and old_version == new_version:
+        _logger.warning("get_changelog_delta called with same old and new version: %s", new_version)
+        return ""
+
     # Resolve old_version boundary; fall back to next entry if old_version unknown
-    old_idx: Optional[int] = None
+    old_idx: int | None = None
     if old_version is not None:
         try:
             old_idx = versions.index(old_version)

--- a/ongabot/utils/changelog.py
+++ b/ongabot/utils/changelog.py
@@ -13,6 +13,15 @@ CHANGELOG_PATH = Path(os.getenv("CHANGELOG_PATH", str(Path(__file__).parent.pare
 
 _VERSION_HEADER_RE = re.compile(r"^## \[([^\]]+)\]", re.MULTILINE)
 
+# A clean release version is exactly MAJOR.MINOR.PATCH. Anything else (e.g. a
+# "1.2.0+dev" build-metadata suffix) marks a development build.
+_RELEASE_VERSION_RE = re.compile(r"\d+\.\d+\.\d+")
+
+
+def is_dev_version(version: str) -> bool:
+    """Return True if version is a development build (not a clean X.Y.Z release)."""
+    return _RELEASE_VERSION_RE.fullmatch(version) is None
+
 
 def get_changelog_delta(
     old_version: str | None,

--- a/ongabot/utils/changelog.py
+++ b/ongabot/utils/changelog.py
@@ -1,0 +1,68 @@
+"""Utilities for reading and parsing CHANGELOG.md."""
+
+import logging
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+_logger = logging.getLogger(__name__)
+
+# In the container: CHANGELOG.md is copied to /ongabot/ (same dir as the code), two levels up from utils/.
+# For local dev outside Docker, override with the CHANGELOG_PATH env var pointing to the repo-root file.
+CHANGELOG_PATH = Path(os.getenv("CHANGELOG_PATH", str(Path(__file__).parent.parent / "CHANGELOG.md")))
+
+_VERSION_HEADER_RE = re.compile(r"^## \[([^\]]+)\]", re.MULTILINE)
+
+
+def get_changelog_delta(
+    old_version: Optional[str],
+    new_version: str,
+    changelog_path: Path = CHANGELOG_PATH,
+) -> str:
+    """Return changelog text covering new_version down to (not including) old_version.
+
+    If old_version is None or not found in the file, returns only the new_version entry.
+    Returns a plain-text fallback if the file is missing or the version is not found.
+    """
+    try:
+        content = changelog_path.read_text(encoding="utf-8")
+    except OSError as e:
+        _logger.error("Failed to read changelog at %s: %s", changelog_path, e)
+        return f"ONGAbot updated to v{new_version}. (Changelog unavailable)"
+
+    matches = list(_VERSION_HEADER_RE.finditer(content))
+    versions = [m.group(1) for m in matches]
+
+    try:
+        new_idx = versions.index(new_version)
+    except ValueError:
+        _logger.warning("Version %s not found in changelog", new_version)
+        return f"ONGAbot updated to v{new_version}. (No changelog entry found)"
+
+    # Resolve old_version boundary; fall back to next entry if old_version unknown
+    old_idx: Optional[int] = None
+    if old_version is not None:
+        try:
+            old_idx = versions.index(old_version)
+        except ValueError:
+            _logger.warning(
+                "Previous version %s not found in changelog; showing only %s entry",
+                old_version,
+                new_version,
+            )
+
+    start_pos = matches[new_idx].start()
+    if old_idx is not None:
+        end_pos = matches[old_idx].start()
+    elif new_idx + 1 < len(matches):
+        end_pos = matches[new_idx + 1].start()
+    else:
+        end_pos = len(content)
+
+    return content[start_pos:end_pos].strip()
+
+
+def get_version_entry(version: str, changelog_path: Path = CHANGELOG_PATH) -> str:
+    """Return the changelog entry for a single version."""
+    return get_changelog_delta(None, version, changelog_path)

--- a/ongabot/utils/changelog.py
+++ b/ongabot/utils/changelog.py
@@ -76,6 +76,38 @@ def get_changelog_delta(
     return content[start_pos:end_pos].strip()
 
 
+def get_changelog(version: str, count: int = 1, changelog_path: Path = CHANGELOG_PATH) -> str:
+    """Return the current changelog section plus the next count-1 sections below it.
+
+    The starting section is [Unreleased] for a development build (is_dev_version),
+    otherwise the section whose header matches the release version. count counts
+    sections including [Unreleased]; values below 1 are treated as 1. Returns a
+    plain-text fallback if the file is missing or the starting section is absent.
+    """
+    try:
+        content = changelog_path.read_text(encoding="utf-8")
+    except OSError as e:
+        _logger.error("Failed to read changelog at %s: %s", changelog_path, e)
+        return f"ONGAbot v{version}. (Changelog unavailable)"
+
+    matches = list(_VERSION_HEADER_RE.finditer(content))
+    versions = [m.group(1) for m in matches]
+
+    start_header = "Unreleased" if is_dev_version(version) else version
+    try:
+        start_idx = versions.index(start_header)
+    except ValueError:
+        _logger.warning("Changelog section %s not found", start_header)
+        return f"ONGAbot v{version}. (No changelog entry found)"
+
+    count = max(1, count)
+    end_section_idx = start_idx + count  # exclusive index into matches
+    start_pos = matches[start_idx].start()
+    end_pos = matches[end_section_idx].start() if end_section_idx < len(matches) else len(content)
+
+    return content[start_pos:end_pos].strip()
+
+
 def get_version_entry(version: str, changelog_path: Path = CHANGELOG_PATH) -> str:
     """Return the changelog entry for a single version."""
     return get_changelog_delta(None, version, changelog_path)

--- a/ongabot/utils/commands.py
+++ b/ongabot/utils/commands.py
@@ -28,9 +28,9 @@ HELP = CommandInfo(
 
 CHANGELOG = CommandInfo(
     command="changelog",
-    brief="/changelog - Show what changed in the current version",
-    usage="/changelog",
-    menu_description="Show what changed in the current version",
+    brief="/changelog - Show recent changelog entries",
+    usage="/changelog [n]\n\nShow the n most recent changelog entries (default 1).",
+    menu_description="Show recent changelog entries",
 )
 
 ONGA = CommandInfo(

--- a/ongabot/utils/commands.py
+++ b/ongabot/utils/commands.py
@@ -26,6 +26,13 @@ HELP = CommandInfo(
     menu_description="Get some aid in needing times",
 )
 
+CHANGELOG = CommandInfo(
+    command="changelog",
+    brief="/changelog - Show what changed in the current version",
+    usage="/changelog",
+    menu_description="Show what changed in the current version",
+)
+
 ONGA = CommandInfo(
     command="onga",
     brief="/onga - This is the way, let me show you",
@@ -154,6 +161,7 @@ BOT_DESCRIPTION = (
 # Ordered for help text assembly
 ALL_COMMANDS = [
     HELP,
+    CHANGELOG,
     ONGA,
     NEWEVENT,
     CANCELEVENT,

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -2,8 +2,8 @@
 
 from datetime import date, datetime, time, timedelta
 
-from .commands import ALL_COMMANDS
 from _version import __version__
+from .commands import ALL_COMMANDS
 
 
 def create_help_text() -> str:

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -3,7 +3,7 @@
 from datetime import date, datetime, time, timedelta
 
 from .commands import ALL_COMMANDS
-from .._version import __version__
+from _version import __version__
 
 
 def create_help_text() -> str:

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -3,6 +3,7 @@
 from datetime import date, datetime, time, timedelta
 
 from _version import __version__
+from .changelog import is_dev_version
 from .commands import ALL_COMMANDS
 
 
@@ -21,7 +22,10 @@ def create_help_text() -> str:
         "Commandments:\n"
     )
     commands = "\n".join(cmd.brief for cmd in ALL_COMMANDS)
-    return f"{header}{commands}\n\nVersion: {__version__}"
+    version_line = f"Version: {__version__}"
+    if is_dev_version(__version__):
+        version_line += " (development build)"
+    return f"{header}{commands}\n\n{version_line}"
 
 
 def get_upcoming_date(today: date, upcoming_weekday: str) -> date:

--- a/ongabot/utils/helper.py
+++ b/ongabot/utils/helper.py
@@ -3,6 +3,7 @@
 from datetime import date, datetime, time, timedelta
 
 from .commands import ALL_COMMANDS
+from .._version import __version__
 
 
 def create_help_text() -> str:
@@ -19,7 +20,8 @@ def create_help_text() -> str:
         "\n"
         "Commandments:\n"
     )
-    return header + "\n".join(cmd.brief for cmd in ALL_COMMANDS)
+    commands = "\n".join(cmd.brief for cmd in ALL_COMMANDS)
+    return f"{header}{commands}\n\nVersion: {__version__}"
 
 
 def get_upcoming_date(today: date, upcoming_weekday: str) -> date:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,5 @@ message = "chore: bump version to {new_version}"
 
 [[tool.bumpversion.files]]
 filename = "ongabot/_version.py"
-search = "__version__ = \"{current_version}\""
+search = "__version__ = \"{current_version}+dev\""
 replace = "__version__ = \"{new_version}\""

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Print or classify the ONGAbot version.
+
+Single source of truth for version/dev-build logic outside the Python runtime.
+The Makefile and CI workflows call this instead of parsing ongabot/_version.py
+with ad-hoc regexes.
+
+Usage:
+    python scripts/version.py            # full version, e.g. 1.2.0+dev
+    python scripts/version.py --base     # X.Y.Z with any suffix stripped
+    python scripts/version.py --is-dev   # exit 0 if a development build, else exit 1
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Make the repo root importable so this runs in bare CI without `pip install`.
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from ongabot._version import __version__  # noqa: E402
+from ongabot.utils.changelog import is_dev_version  # noqa: E402
+
+
+def full_version() -> str:
+    """Return the full version string, e.g. '1.2.0+dev'."""
+    return __version__
+
+
+def base_version() -> str:
+    """Return the clean X.Y.Z base, stripping any pre-release/build suffix."""
+    match = re.match(r"\d+\.\d+\.\d+", __version__)
+    if not match:
+        raise ValueError(f"Cannot parse base version from {__version__!r}")
+    return match.group(0)
+
+
+def is_dev() -> bool:
+    """Return True if the current build is a development build."""
+    return is_dev_version(__version__)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Print or classify the ONGAbot version.")
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument("--base", action="store_true", help="print X.Y.Z with any suffix stripped")
+    group.add_argument("--is-dev", action="store_true", help="exit 0 if a development build, else 1")
+    group.add_argument("--full", action="store_true", help="print the full version (default)")
+    args = parser.parse_args(argv)
+
+    if args.is_dev:
+        return 0 if is_dev() else 1
+    if args.base:
+        print(base_version())
+        return 0
+    print(full_version())
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_botdata.py
+++ b/tests/test_botdata.py
@@ -15,11 +15,11 @@ class BotDataDefaultsTest(unittest.TestCase):
 
 
 class BotDataSetStateTest(unittest.TestCase):
-    def test_migration_adds_last_known_version_when_missing(self):
+    def test_migration_seeds_known_starting_point_when_missing(self):
         bd = BotData.__new__(BotData)
-        # Simulate an old pickle that has no last_known_version
+        # Simulate an old pickle predating version tracking
         bd.__setstate__({"chats": {}, "authorized_chats": set()})
-        self.assertIsNone(bd.last_known_version)
+        self.assertEqual(bd.last_known_version, "1.2.0")
 
     def test_migration_preserves_existing_last_known_version(self):
         bd = BotData.__new__(BotData)

--- a/tests/test_botdata.py
+++ b/tests/test_botdata.py
@@ -1,0 +1,36 @@
+import unittest
+
+from ongabot.botdata import BotData
+
+
+class BotDataDefaultsTest(unittest.TestCase):
+    def test_last_known_version_defaults_to_none(self):
+        bd = BotData()
+        self.assertIsNone(bd.last_known_version)
+
+    def test_last_known_version_can_be_set(self):
+        bd = BotData()
+        bd.last_known_version = "1.2.0"
+        self.assertEqual(bd.last_known_version, "1.2.0")
+
+
+class BotDataSetStateTest(unittest.TestCase):
+    def test_migration_adds_last_known_version_when_missing(self):
+        bd = BotData.__new__(BotData)
+        # Simulate an old pickle that has no last_known_version
+        bd.__setstate__({"chats": {}, "authorized_chats": set()})
+        self.assertIsNone(bd.last_known_version)
+
+    def test_migration_preserves_existing_last_known_version(self):
+        bd = BotData.__new__(BotData)
+        bd.__setstate__({"chats": {}, "authorized_chats": set(), "last_known_version": "1.1.0"})
+        self.assertEqual(bd.last_known_version, "1.1.0")
+
+    def test_migration_adds_authorized_chats_when_missing(self):
+        bd = BotData.__new__(BotData)
+        bd.__setstate__({"chats": {}})
+        self.assertEqual(bd.authorized_chats, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from ongabot.utils.changelog import get_changelog, get_changelog_delta, get_version_entry, is_dev_version
+from ongabot.utils.changelog import get_changelog, get_changelog_delta, is_dev_version
 
 SAMPLE = """\
 # Changelog
@@ -84,22 +84,6 @@ class GetChangelogDeltaTest(unittest.TestCase):
         result = get_changelog_delta(None, "1.0.0", self.path)
         self.assertIn("1.0.0", result)
         self.assertNotIn("1.1.0", result)
-
-
-class GetVersionEntryTest(unittest.TestCase):
-    def setUp(self):
-        self._dir = tempfile.TemporaryDirectory()
-        self.tmp = Path(self._dir.name)
-        self.path = _write_sample(self.tmp)
-
-    def tearDown(self):
-        self._dir.cleanup()
-
-    def test_returns_single_version_section(self):
-        result = get_version_entry("1.1.0", self.path)
-        self.assertIn("1.1.0", result)
-        self.assertNotIn("1.2.0", result)
-        self.assertNotIn("1.0.0", result)
 
 
 class IsDevVersionTest(unittest.TestCase):

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -80,6 +80,11 @@ class GetChangelogDeltaTest(unittest.TestCase):
         result = get_changelog_delta(None, "1.2.0", self.path)
         self.assertNotIn("Unreleased", result)
 
+    def test_oldest_version_is_last_in_file_returns_full_entry(self):
+        result = get_changelog_delta(None, "1.0.0", self.path)
+        self.assertIn("1.0.0", result)
+        self.assertNotIn("1.1.0", result)
+
 
 class GetVersionEntryTest(unittest.TestCase):
     def setUp(self):

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from ongabot.utils.changelog import get_changelog_delta, get_version_entry, is_dev_version
+from ongabot.utils.changelog import get_changelog, get_changelog_delta, get_version_entry, is_dev_version
 
 SAMPLE = """\
 # Changelog
@@ -114,6 +114,58 @@ class IsDevVersionTest(unittest.TestCase):
 
     def test_non_semver_is_dev(self):
         self.assertTrue(is_dev_version("nightly"))
+
+
+class GetChangelogTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._dir.name)
+        self.path = _write_sample(self.tmp)
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def test_dev_build_shows_unreleased(self):
+        result = get_changelog("1.2.0+dev", 1, self.path)
+        self.assertIn("Unreleased", result)
+        self.assertNotIn("1.2.0", result)
+
+    def test_release_build_shows_its_section(self):
+        result = get_changelog("1.2.0", 1, self.path)
+        self.assertIn("1.2.0", result)
+        self.assertNotIn("Unreleased", result)
+        self.assertNotIn("1.1.0", result)
+
+    def test_dev_build_count_includes_unreleased_and_releases(self):
+        result = get_changelog("1.2.0+dev", 3, self.path)
+        self.assertIn("Unreleased", result)
+        self.assertIn("1.2.0", result)
+        self.assertIn("1.1.0", result)
+        self.assertNotIn("1.0.0", result)
+
+    def test_release_build_count_walks_downward(self):
+        result = get_changelog("1.2.0", 2, self.path)
+        self.assertIn("1.2.0", result)
+        self.assertIn("1.1.0", result)
+        self.assertNotIn("1.0.0", result)
+
+    def test_count_larger_than_history_stops_at_end(self):
+        result = get_changelog("1.0.0", 5, self.path)
+        self.assertIn("1.0.0", result)
+
+    def test_count_below_one_treated_as_one(self):
+        result = get_changelog("1.2.0", 0, self.path)
+        self.assertIn("1.2.0", result)
+        self.assertNotIn("1.1.0", result)
+
+    def test_missing_file_returns_fallback(self):
+        missing = self.tmp / "no_such_file.md"
+        result = get_changelog("1.2.0", 1, missing)
+        self.assertIn("1.2.0", result)
+
+    def test_unknown_release_version_returns_fallback(self):
+        result = get_changelog("9.9.9", 1, self.path)
+        self.assertIn("9.9.9", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -2,7 +2,7 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from ongabot.utils.changelog import get_changelog_delta, get_version_entry
+from ongabot.utils.changelog import get_changelog_delta, get_version_entry, is_dev_version
 
 SAMPLE = """\
 # Changelog
@@ -100,6 +100,20 @@ class GetVersionEntryTest(unittest.TestCase):
         self.assertIn("1.1.0", result)
         self.assertNotIn("1.2.0", result)
         self.assertNotIn("1.0.0", result)
+
+
+class IsDevVersionTest(unittest.TestCase):
+    def test_clean_release_is_not_dev(self):
+        self.assertFalse(is_dev_version("1.2.0"))
+
+    def test_plus_dev_suffix_is_dev(self):
+        self.assertTrue(is_dev_version("1.2.0+dev"))
+
+    def test_hyphen_suffix_is_dev(self):
+        self.assertTrue(is_dev_version("1.2.0-rc1"))
+
+    def test_non_semver_is_dev(self):
+        self.assertTrue(is_dev_version("nightly"))
 
 
 if __name__ == "__main__":

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,101 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from ongabot.utils.changelog import get_changelog_delta, get_version_entry
+
+SAMPLE = """\
+# Changelog
+
+## [Unreleased]
+
+## [1.2.0] - 2026-05-24
+
+### Fixed
+
+- Big fix
+
+## [1.1.0] - 2026-05-01
+
+### Added
+
+- New feature
+
+## [1.0.0] - 2026-01-01
+
+### Added
+
+- Initial release
+"""
+
+
+def _write_sample(tmp: Path) -> Path:
+    p = tmp / "CHANGELOG.md"
+    p.write_text(SAMPLE)
+    return p
+
+
+class GetChangelogDeltaTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._dir.name)
+        self.path = _write_sample(self.tmp)
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def test_none_old_version_returns_only_new_entry(self):
+        result = get_changelog_delta(None, "1.2.0", self.path)
+        self.assertIn("1.2.0", result)
+        self.assertNotIn("1.1.0", result)
+        self.assertNotIn("1.0.0", result)
+
+    def test_adjacent_versions_returns_new_entry_only(self):
+        result = get_changelog_delta("1.1.0", "1.2.0", self.path)
+        self.assertIn("1.2.0", result)
+        self.assertNotIn("1.1.0", result)
+
+    def test_two_version_gap_returns_both_entries(self):
+        result = get_changelog_delta("1.0.0", "1.2.0", self.path)
+        self.assertIn("1.2.0", result)
+        self.assertIn("1.1.0", result)
+        self.assertNotIn("1.0.0", result)
+
+    def test_unknown_new_version_returns_fallback(self):
+        result = get_changelog_delta(None, "9.9.9", self.path)
+        self.assertIn("9.9.9", result)
+
+    def test_unknown_old_version_returns_new_entry_only(self):
+        # Unknown old version falls back to showing just new entry
+        result = get_changelog_delta("0.0.0", "1.2.0", self.path)
+        self.assertIn("1.2.0", result)
+        self.assertNotIn("1.1.0", result)
+
+    def test_missing_file_returns_fallback(self):
+        missing = self.tmp / "no_such_file.md"
+        result = get_changelog_delta(None, "1.2.0", missing)
+        self.assertIn("1.2.0", result)
+
+    def test_unreleased_section_excluded_from_adjacent_entry(self):
+        result = get_changelog_delta(None, "1.2.0", self.path)
+        self.assertNotIn("Unreleased", result)
+
+
+class GetVersionEntryTest(unittest.TestCase):
+    def setUp(self):
+        self._dir = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._dir.name)
+        self.path = _write_sample(self.tmp)
+
+    def tearDown(self):
+        self._dir.cleanup()
+
+    def test_returns_single_version_section(self):
+        result = get_version_entry("1.1.0", self.path)
+        self.assertIn("1.1.0", result)
+        self.assertNotIn("1.2.0", result)
+        self.assertNotIn("1.0.0", result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,3 +1,4 @@
+import re
 import tempfile
 import unittest
 from pathlib import Path
@@ -170,6 +171,30 @@ class GetChangelogTest(unittest.TestCase):
     def test_unknown_release_version_returns_fallback(self):
         result = get_changelog("9.9.9", 1, self.path)
         self.assertIn("9.9.9", result)
+
+
+class RealChangelogTest(unittest.TestCase):
+    real_path = Path(__file__).resolve().parent.parent / "CHANGELOG.md"
+
+    def _oldest_release(self):
+        content = self.real_path.read_text(encoding="utf-8")
+        versions = re.findall(r"^## \[([^\]]+)\]", content, re.MULTILINE)
+        releases = [v for v in versions if re.fullmatch(r"\d+\.\d+\.\d+", v)]
+        self.assertTrue(releases, "no release headers found in real CHANGELOG.md")
+        return releases[-1]
+
+    def test_full_range_excludes_link_reference_block(self):
+        oldest = self._oldest_release()
+        result = get_changelog(oldest, 99, self.real_path)
+        self.assertIn(oldest, result)
+        self.assertNotIn("http", result)
+        self.assertNotIn("]: ", result)
+
+    def test_delta_to_oldest_excludes_link_reference_block(self):
+        oldest = self._oldest_release()
+        result = get_changelog_delta(None, oldest, self.real_path)
+        self.assertNotIn("http", result)
+        self.assertNotIn("]: ", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -26,6 +26,11 @@ SAMPLE = """\
 ### Added
 
 - Initial release
+
+[Unreleased]: https://github.com/tingvarsson/telegram.ongabot/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/tingvarsson/telegram.ongabot/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.com/tingvarsson/telegram.ongabot/compare/v1.0.0...v1.1.0
+[1.0.0]: https://github.com/tingvarsson/telegram.ongabot/releases/tag/v1.0.0
 """
 
 
@@ -85,6 +90,13 @@ class GetChangelogDeltaTest(unittest.TestCase):
         self.assertIn("1.0.0", result)
         self.assertNotIn("1.1.0", result)
 
+    def test_oldest_version_excludes_trailing_link_reference_block(self):
+        # 1.0.0 is both the "new" and only version reachable, so the slice
+        # runs to EOF and must not swallow the trailing link-reference block.
+        result = get_changelog_delta(None, "1.0.0", self.path)
+        self.assertNotIn("http", result)
+        self.assertNotIn("]: ", result)
+
 
 class IsDevVersionTest(unittest.TestCase):
     def test_clean_release_is_not_dev(self):
@@ -136,6 +148,14 @@ class GetChangelogTest(unittest.TestCase):
     def test_count_larger_than_history_stops_at_end(self):
         result = get_changelog("1.0.0", 5, self.path)
         self.assertIn("1.0.0", result)
+
+    def test_oldest_section_excludes_trailing_link_reference_block(self):
+        # Reaching the last section in the file means the slice runs to EOF;
+        # the trailing link-reference block must not leak into the output.
+        result = get_changelog("1.0.0", 1, self.path)
+        self.assertIn("Initial release", result)
+        self.assertNotIn("http", result)
+        self.assertNotIn("]: ", result)
 
     def test_count_below_one_treated_as_one(self):
         result = get_changelog("1.2.0", 0, self.path)

--- a/tests/test_changelogcommandhandler.py
+++ b/tests/test_changelogcommandhandler.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from ongabot.handler.changelogcommandhandler import callback
+
+
+class ChangelogCommandHandlerTest(unittest.IsolatedAsyncioTestCase):
+    def _make(self, args):
+        update = MagicMock()
+        update.message.reply_text = AsyncMock()
+        context = MagicMock()
+        context.args = args
+        return update, context
+
+    async def test_default_count_is_one(self):
+        update, context = self._make([])
+        with patch("ongabot.handler.changelogcommandhandler.get_changelog", return_value="ENTRY") as gc:
+            await callback(update, context)
+        self.assertEqual(gc.call_args.args[1], 1)
+        update.message.reply_text.assert_awaited_once_with("ENTRY")
+
+    async def test_explicit_count_passed_through(self):
+        update, context = self._make(["3"])
+        with patch("ongabot.handler.changelogcommandhandler.get_changelog", return_value="E") as gc:
+            await callback(update, context)
+        self.assertEqual(gc.call_args.args[1], 3)
+
+    async def test_invalid_count_replies_usage_and_skips_lookup(self):
+        update, context = self._make(["abc"])
+        with patch("ongabot.handler.changelogcommandhandler.get_changelog") as gc:
+            await callback(update, context)
+        gc.assert_not_called()
+        update.message.reply_text.assert_awaited_once()
+
+    async def test_zero_count_replies_usage(self):
+        update, context = self._make(["0"])
+        with patch("ongabot.handler.changelogcommandhandler.get_changelog") as gc:
+            await callback(update, context)
+        gc.assert_not_called()
+        update.message.reply_text.assert_awaited_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -2,6 +2,7 @@ from ongabot.utils import helper
 
 from datetime import date, time
 from parameterized import parameterized
+from unittest.mock import patch
 import unittest
 
 
@@ -187,6 +188,17 @@ class CreateHelpTextTest(unittest.TestCase):
     def test_help_text_contains_commandments_header(self):
         result = helper.create_help_text()
         self.assertIn("Commandments:", result)
+
+    def test_help_text_marks_development_build(self):
+        with patch.object(helper, "__version__", "1.2.0+dev"):
+            result = helper.create_help_text()
+        self.assertIn("1.2.0+dev", result)
+        self.assertIn("development build", result)
+
+    def test_help_text_no_marker_on_release(self):
+        with patch.object(helper, "__version__", "1.2.0"):
+            result = helper.create_help_text()
+        self.assertNotIn("development build", result)
 
 
 if __name__ == "__main__":

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -177,5 +177,16 @@ class ParseEventJobArgsTest(unittest.TestCase):
             helper.parse_event_job_args(args, *self.DEFAULTS)
 
 
+class CreateHelpTextTest(unittest.TestCase):
+    def test_help_text_contains_version(self):
+        import ongabot
+        result = helper.create_help_text()
+        self.assertIn(ongabot.__version__, result)
+
+    def test_help_text_contains_commandments_header(self):
+        result = helper.create_help_text()
+        self.assertIn("Commandments:", result)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -180,6 +180,7 @@ class ParseEventJobArgsTest(unittest.TestCase):
 class CreateHelpTextTest(unittest.TestCase):
     def test_help_text_contains_version(self):
         import ongabot
+
         result = helper.create_help_text()
         self.assertIn(ongabot.__version__, result)
 

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -233,6 +233,20 @@ class PostInitVersionTrackingTest(unittest.IsolatedAsyncioTestCase):
             await post_init(application)
         self.assertEqual(application.bot_data.last_known_version, "1.2.0")
 
+    async def test_no_announcement_on_dev_build(self):
+        application = self._make_application(stored_version="1.2.0")
+        with patch.object(ongabot, "CURRENT_VERSION", "1.2.0+dev"):
+            await post_init(application)
+        application.bot.send_message.assert_not_called()
+        self.assertEqual(application.bot_data.last_known_version, "1.2.0")
+
+    async def test_dev_build_does_not_seed_version_when_none(self):
+        application = self._make_application(stored_version=None)
+        with patch.object(ongabot, "CURRENT_VERSION", "1.2.0+dev"):
+            await post_init(application)
+        application.bot.send_message.assert_not_called()
+        self.assertIsNone(application.bot_data.last_known_version)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_ongabot.py
+++ b/tests/test_ongabot.py
@@ -1,6 +1,6 @@
 import unittest
 from datetime import date
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from telegram.error import TelegramError
 
@@ -152,6 +152,86 @@ class SetupBotMetadataTest(unittest.IsolatedAsyncioTestCase):
         await setup_bot_metadata(bot)  # must not raise
         bot.set_my_commands.assert_called_once()
         bot.set_my_description.assert_called_once()
+
+
+class AnnounceNewVersionTest(unittest.IsolatedAsyncioTestCase):
+    async def test_sends_message_to_all_authorized_chats(self):
+        bot = AsyncMock()
+        bot_data = MagicMock()
+        bot_data.authorized_chats = {101, 202}
+
+        await ongabot._announce_new_version(bot, bot_data, "1.1.0", "1.2.0")
+
+        self.assertEqual(bot.send_message.call_count, 2)
+        sent_chat_ids = {call.kwargs["chat_id"] for call in bot.send_message.call_args_list}
+        self.assertEqual(sent_chat_ids, {101, 202})
+
+    async def test_continues_when_one_chat_raises_telegram_error(self):
+        from telegram.error import TelegramError
+
+        bot = AsyncMock()
+        bot.send_message.side_effect = [TelegramError("forbidden"), None]
+        bot_data = MagicMock()
+        bot_data.authorized_chats = {101, 202}
+
+        await ongabot._announce_new_version(bot, bot_data, "1.1.0", "1.2.0")
+
+        self.assertEqual(bot.send_message.call_count, 2)
+
+    async def test_message_contains_new_version(self):
+        bot = AsyncMock()
+        bot_data = MagicMock()
+        bot_data.authorized_chats = {101}
+
+        await ongabot._announce_new_version(bot, bot_data, "1.1.0", "1.2.0")
+
+        text = bot.send_message.call_args.kwargs["text"]
+        self.assertIn("1.2.0", text)
+
+    async def test_no_messages_sent_when_no_authorized_chats(self):
+        bot = AsyncMock()
+        bot_data = MagicMock()
+        bot_data.authorized_chats = set()
+
+        await ongabot._announce_new_version(bot, bot_data, "1.1.0", "1.2.0")
+
+        bot.send_message.assert_not_called()
+
+
+class PostInitVersionTrackingTest(unittest.IsolatedAsyncioTestCase):
+    def _make_application(self, stored_version):
+        application = MagicMock()
+        application.bot = AsyncMock()
+        application.bot_data.last_known_version = stored_version
+        application.bot_data.authorized_chats = {101}
+        application.bot_data.schedule_all_event_jobs.return_value = None
+        application.job_queue = MagicMock()
+        return application
+
+    async def test_announces_when_version_changed(self):
+        application = self._make_application(stored_version="1.1.0")
+        with patch.object(ongabot, "CURRENT_VERSION", "1.2.0"):
+            await post_init(application)
+        application.bot.send_message.assert_called_once()
+
+    async def test_no_announcement_when_version_unchanged(self):
+        application = self._make_application(stored_version="1.2.0")
+        with patch.object(ongabot, "CURRENT_VERSION", "1.2.0"):
+            await post_init(application)
+        application.bot.send_message.assert_not_called()
+
+    async def test_no_announcement_on_first_run_stores_version(self):
+        application = self._make_application(stored_version=None)
+        with patch.object(ongabot, "CURRENT_VERSION", "1.2.0"):
+            await post_init(application)
+        application.bot.send_message.assert_not_called()
+        self.assertEqual(application.bot_data.last_known_version, "1.2.0")
+
+    async def test_updates_stored_version_after_announcement(self):
+        application = self._make_application(stored_version="1.1.0")
+        with patch.object(ongabot, "CURRENT_VERSION", "1.2.0"):
+            await post_init(application)
+        self.assertEqual(application.bot_data.last_known_version, "1.2.0")
 
 
 if __name__ == "__main__":

--- a/tests/test_version_script.py
+++ b/tests/test_version_script.py
@@ -1,0 +1,62 @@
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import scripts.version as version_script
+from ongabot._version import __version__
+from ongabot.utils.changelog import is_dev_version
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "version.py"
+
+
+def _run(*args):
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=REPO_ROOT,
+    )
+
+
+class VersionScriptCliTest(unittest.TestCase):
+    def test_full_is_single_line_starting_with_semver(self):
+        result = _run()
+        self.assertEqual(result.returncode, 0)
+        out = result.stdout.strip()
+        self.assertEqual(len(out.splitlines()), 1)
+        self.assertRegex(out, r"^\d+\.\d+\.\d+")
+
+    def test_base_is_clean_semver_single_line(self):
+        result = _run("--base")
+        self.assertEqual(result.returncode, 0)
+        out = result.stdout.strip()
+        self.assertEqual(len(out.splitlines()), 1)
+        self.assertRegex(out, r"^\d+\.\d+\.\d+$")
+
+    def test_is_dev_exit_code_matches_runtime_rule(self):
+        result = _run("--is-dev")
+        expected = 0 if is_dev_version(__version__) else 1
+        self.assertEqual(result.returncode, expected)
+
+
+class VersionScriptUnitTest(unittest.TestCase):
+    def test_base_strips_dev_suffix(self):
+        with patch.object(version_script, "__version__", "1.3.0+dev"):
+            self.assertEqual(version_script.base_version(), "1.3.0")
+
+    def test_base_of_clean_release(self):
+        with patch.object(version_script, "__version__", "1.3.0"):
+            self.assertEqual(version_script.base_version(), "1.3.0")
+
+    def test_is_dev_true_for_suffix_false_for_clean(self):
+        with patch.object(version_script, "__version__", "1.3.0+dev"):
+            self.assertTrue(version_script.is_dev())
+        with patch.object(version_script, "__version__", "1.3.0"):
+            self.assertFalse(version_script.is_dev())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds versioning observability to ONGAbot and makes it **development-build aware**.

### Commands & display
- **`/changelog [n]`** — shows the `n` most recent changelog entries (default 1). On a development build the current entry is the `[Unreleased]` section; on a release it is that release's section.
- **`/help`** shows the running version, marked `(development build)` when the build is not a clean release.

### Startup announcements
- On a **release upgrade**, broadcasts the changelog delta to all authorized chats.
- On a **development build**, announcements are skipped and `last_known_version` is left untouched, so the next real release still announces the full delta.
- **Fresh install** on a release records the version silently (nothing to announce).
- `BotData.last_known_version` persists the last-seen release across restarts; deployments predating version tracking are migrated to a `1.2.0` starting point (fresh installs default to `None`).

### Version scheme & release tooling
- Between releases `ongabot/_version.py` carries a `+dev` build-metadata suffix on the last release (e.g. `1.2.0+dev`), marking a development build. `is_dev_version()` treats anything that is not clean `X.Y.Z` semver as a dev build. Version strings are compared only by equality and `is_dev_version` — never by ordering.
- `pyproject.toml` bumpversion strips `+dev` on release; `make post-release` re-adds it to the new base. Version extraction in the `Makefile` is anchored to the `__version__` line.

### Packaging
- Copies `CHANGELOG.md` into the Docker image; adds `CHANGELOG_PATH` env var to `.env.example` for local dev.

## Test plan

- [x] `make test` — 192 tests pass, coverage 74% (floor 46%)
- [x] `make check` — pylint 10/10, black unchanged, flake8 + mypy clean
- [x] `/changelog` on a dev build returns the `[Unreleased]` section; `/changelog N` walks down N sections; trailing CHANGELOG link-reference block is excluded from output (verified at runtime against the real `CHANGELOG.md`)
- [x] `/help` ends with `Version: 1.2.0+dev (development build)` on a dev build
- [x] `bump-my-version bump minor --dry-run` on `1.2.0+dev` produces `1.3.0` (release tooling verified)
- [ ] Deploy a real release over an existing DB — authorized chats receive a startup announcement with the changelog delta
- [ ] Restart at the same release — no announcement; logs show version unchanged
- [ ] Restart a dev build — no announcement; `last_known_version` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)
